### PR TITLE
Light Refactoring on Pipeline Builder Logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
   - docker-compose
 
 install:
-  - docker login -u $D3M_REGISTRY_USER -p $D3M_REGISTRY_PASSWORD registry.datadrivendiscovery.org/
+  - echo $D3M_REGISTRY_PASSWORD | docker login -u $D3M_REGISTRY_USER --password-stdin registry.datadrivendiscovery.org/
   - cd test
 
 script:

--- a/experimenter/pipeline_builder.py
+++ b/experimenter/pipeline_builder.py
@@ -1,0 +1,55 @@
+from d3m import index as d3m_index
+from d3m.metadata.pipeline import Pipeline
+from d3m.metadata.pipeline import PrimitiveStep
+from d3m.metadata.base import ArgumentType
+
+def create_pipeline_step(
+    step_counter: int,
+    python_path: str,
+    *,
+    input_data_reference: str = None,
+    input_argument_type: ArgumentType = ArgumentType.CONTAINER,
+    output_name: str = 'produce'
+) -> PrimitiveStep:
+    """
+    Helper for creating a d3m.metadata.pipeline.PrimitiveStep in a less verbose manner.
+
+    :param step_counter: an integer representing the step number this call will create.
+    :param python_path: the python path of the primitive to be added.
+    :param input_data_reference: an optional custom data reference string for the primitive's inputs.
+        If not provided, the default will be `'steps.{step_counter - 1}.produce'`, i.e. the output
+        of the previous step.
+    :param input_argument_type: an optional input argument type to use for the primitive.
+    :param output_name: an optional method output name to use for the primitive.
+    
+    :return step: the constructed primitive step.
+    """
+    if input_data_reference is None:
+        input_data_reference = f'steps.{step_counter - 1}.produce'
+    
+    step = PrimitiveStep(
+        primitive=d3m_index.get_primitive(python_path))
+    step.add_argument(
+        name='inputs',
+        argument_type=input_argument_type,
+        data_reference=input_data_reference
+        )
+    step.add_output(output_name)
+
+    return step
+
+def add_pipeline_step(pipeline_description: Pipeline, step_counter: int, *args, **kwargs) -> int:
+    """
+    A helper method. Adds the results of `create_pipeline_step` to `pipeline_description`,
+    returning the updated step counter.
+
+    :param pipeline_description: The pipeline to add a step to.
+    :param step_counter: an integer representing the step number this call will create.
+    :param *args: The rest of the positional args to forward to `create_pipeline_step`.
+    :param **kwargs: The rest of the keyword args to forward to `create_pipeline_step`.
+
+    :return: The updated step counter
+    """
+    step = create_pipeline_step(step_counter, *args, **kwargs)
+    pipeline_description.add_step(step)
+    return step_counter + 1

--- a/test/test_ensembling_pipelines_generation.py
+++ b/test/test_ensembling_pipelines_generation.py
@@ -114,8 +114,9 @@ class TestEnsemblingPipelinesGeneration(unittest.TestCase):
 
         primitives = primitive_list_from_pipeline_json(generated_pipelines["classification"][0].to_json_structure())
         primitives_used = set(primitives)
-        primitives_repeated = 16  # preprocessor repeats 5 times, model repeats 5 times, concat repeats 2 times and
-                                 # construct predictiond repeats 5 times
+        # extract by semantic types repeats 2 times, preprocessor repeats 5 times, model repeats 5 times,
+        # concat repeats 2 times, and construct predictions repeats 5 times
+        primitives_repeated = 17                     
         self.assertEqual(len(primitives_used), len(primitives) - primitives_repeated,
                          msg="The expected number of unique primitives was {} but we got {}".format(len(primitives) -
                                                                                                     primitives_repeated,

--- a/test/test_pipeline_generator.py
+++ b/test/test_pipeline_generator.py
@@ -39,10 +39,12 @@ class PipelineGenerationTestCase(unittest.TestCase):
     
     def test_basic_pipeline_structure(self):
 
-        num_pipeline_steps = 6  # DatasetToDataFrame/ColumnParser/SKImputer/ExtractSemanticTypes/
+        num_pipeline_steps = 7  # DatasetToDataFrame/ColumnParser/SKImputer/
+                                # ExtractSemanticTypes(attributes)/
+                                # ExtractSemanticTypes(targets)/
                                 # SKGaussianNB/ConstructPredictions
-        pipeline_step_zero = 'd3m.primitives.data_transformation.dataset_to_dataframe.Common'
-        pipeline_step_four = 'd3m.primitives.data_transformation.construct_predictions.DataFrameCommon'
+        dataset_to_dataframe = 'd3m.primitives.data_transformation.dataset_to_dataframe.Common'
+        construct_predictions = 'd3m.primitives.data_transformation.construct_predictions.DataFrameCommon'
 
         print("Testing that the pipelines are what they should be...")
         # should only make one pipeline with no preprocessor
@@ -56,5 +58,5 @@ class PipelineGenerationTestCase(unittest.TestCase):
         generated_pipelines = self.experimenter_driver.generated_pipelines['classification'][0].to_json_structure()
         # make sure there are the normal number of steps in the pipeline
         self.assertEqual(len(generated_pipelines['steps']), num_pipeline_steps)
-        self.assertEqual(generated_pipelines['steps'][0]['primitive']['python_path'], pipeline_step_zero)
-        self.assertEqual(generated_pipelines['steps'][5]['primitive']['python_path'], pipeline_step_four)
+        self.assertEqual(generated_pipelines['steps'][0]['primitive']['python_path'], dataset_to_dataframe)
+        self.assertEqual(generated_pipelines['steps'][6]['primitive']['python_path'], construct_predictions)


### PR DESCRIPTION
I added pipeline step builder helpers and decoupled pipeline building inside `experimenter.py` from using static step numbers (except for when using the raw dataframe in `"steps.0.produce"`, that's still static). I did this so the ordinal encoder and one hot encoder primitives can be added more easily to `experimenter._add_initial_steps`.