### PR TITLE
Factor out experiments

### DIFF
--- a/experimenter/experimenter.py
+++ b/experimenter/experimenter.py
@@ -20,6 +20,11 @@ from bson import json_util
 from d3m.metadata import base as metadata_base, problem as base_problem
 from experimenter.autosklearn.pipelines import get_classification_pipeline, AutoSklearnClassifierPrimitive
 from experimenter.pipeline_builder import add_pipeline_step, create_pipeline_step
+from experimenter.experiments.metafeatures import MetafeatureExperimenter
+from experimenter.experiments.random import RandomArchitectureExperimenter
+from experimenter.experiments.straight import StraightArchitectureExperimenter
+from experimenter.experiments.ensemble import EnsembleArchitectureExperimenter
+from experimenter.experiments.stacked import StackedArchitectureExperimenter
 
 from experimenter import utils
 
@@ -31,9 +36,10 @@ class Experimenter:
     generates pipelines.  This class is used by the ExperimenterDriver class to run the pipelines.
     """
 
-    def __init__(self, datasets_dir: str, volumes_dir: str, input_problem_directory=None,
-                 input_models=None, input_preprocessors=None, generate_pipelines=True, args: dict = None,
-                 location=None, generate_problems=False, generate_automl_pipelines=False):
+    def __init__(self, datasets_dir: str, volumes_dir: str, *, input_problem_directory=None,
+                 input_models=None, input_preprocessors=None, generate_pipelines=True,
+                 location=None, generate_problems=False, generate_automl_pipelines=False,
+                 pipeline_gen_type: str = "straight", n_classifiers: int = 3, n_preprocessors: int = 1):
         self.datasets_dir = datasets_dir
         self.volumes_dir = volumes_dir
         self.mongo_database = PipelineDB()
@@ -58,18 +64,29 @@ class Experimenter:
 
             logger.info("There are {} problems".format(self.num_problems))
 
-        if generate_pipelines:
-            logger.info("Generating pipelines of type {}".format(args.pipeline_gen_type))
-            if args.pipeline_gen_type == "metafeatures":
-                self.generated_pipelines: dict = self.generate_metafeatures_pipeline()
-            elif args.pipeline_gen_type == "random":
-                raise NotImplementedError("Random has not been implemented") # TODO: add random search
-            elif args.pipeline_gen_type == "straight":
-                self.generated_pipelines: dict = self.generate_pipelines(self.preprocessors, self.models)
-            elif args.pipeline_gen_type == "ensemble":
-                self.generated_pipelines: dict = self._wrap_generate_all_ensembles(k_ensembles=args.n_classifiers, p_preprocessors=args.n_preprocessors)
+        if generate_pipelines:            
+            logger.info("Generating pipelines of type {}".format(pipeline_gen_type))
+            
+            if pipeline_gen_type == "metafeatures":
+                self.generated_pipelines = MetafeatureExperimenter().generate_pipelines()
+            elif pipeline_gen_type == "random":
+                self.generated_pipelines = RandomArchitectureExperimenter().generate_pipelines()
+            elif pipeline_gen_type == "straight":
+                self.generated_pipelines = StraightArchitectureExperimenter().generate_pipelines(
+                    self.preprocessors,
+                    self.models
+                )
+            elif pipeline_gen_type == "ensemble":
+                self.generated_pipelines = EnsembleArchitectureExperimenter().generate_pipelines(
+                    self.preprocessors,
+                    self.models,
+                    n_classifiers,
+                    n_preprocessors
+                )
+            elif pipeline_gen_type == "stacked":
+                self.generated_pipelines = StackedArchitectureExperimenter().generate_pipelines()
             else:
-                raise Exception("Cannot parse generation type {}".format(args.pipeline_gen_type))
+                raise Exception("Cannot parse generation type {}".format(pipeline_gen_type))
 
             self.num_pipelines = len(self.generated_pipelines["classification"]) + len(self.generated_pipelines["regression"])
 
@@ -87,143 +104,6 @@ class Experimenter:
             self.generated_pipelines = self.generate_baseline_pipelines()
             self.num_pipelines = len(self.generated_pipelines["classification"])
             self.output_automl_pipelines_to_mongodb()
-
-    def _add_initial_steps(self, pipeline_description: EZPipeline) -> None:
-        """
-        :param pipeline_description: an empty pipeline object that we can add
-            the initial data preparation steps to.
-        """
-        # Creating pipeline
-        pipeline_description.add_input(name='inputs')
-
-        # dataset_to_dataframe step
-        add_pipeline_step(
-            pipeline_description,
-            'd3m.primitives.data_transformation.dataset_to_dataframe.Common',
-            'inputs.0'
-        )
-        pipeline_description.set_step_i_of('raw_df')
-
-        # column_parser step
-        add_pipeline_step(
-            pipeline_description,
-            'd3m.primitives.data_transformation.column_parser.DataFrameCommon'
-        )
-
-        # imputer step
-        add_pipeline_step(
-            pipeline_description,
-            'd3m.primitives.data_preprocessing.random_sampling_imputer.BYU'
-        )
-
-        # extract_columns_by_semantic_types(attributes) step
-        extract_attributes_step = create_pipeline_step(
-            'd3m.primitives.data_transformation.extract_columns_by_semantic_types.DataFrameCommon',
-            pipeline_description.curr_step_data_ref
-        )
-        extract_attributes_step.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE,
-                                  data=['https://metadata.datadrivendiscovery.org/types/Attribute'])
-        pipeline_description.add_step(extract_attributes_step)
-        pipeline_description.set_step_i_of('attrs')
-
-        # extract_columns_by_semantic_types(targets) step
-        extract_targets_step = create_pipeline_step(
-            'd3m.primitives.data_transformation.extract_columns_by_semantic_types.DataFrameCommon',
-            pipeline_description.data_ref_of('raw_df')
-        )
-        extract_targets_step.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE,
-                                  data=['https://metadata.datadrivendiscovery.org/types/TrueTarget'])
-        pipeline_description.add_step(extract_targets_step)
-        pipeline_description.set_step_i_of('target')
-
-    def _add_predictions_constructor(self, pipeline_description: EZPipeline, input_data_ref: str = None) -> None:
-        """
-        Adds the predictions constructor to a pipeline description and increments the step counter
-        :param pipeline_description: the pipeline-to-be
-        :param input_data_ref: the data reference to be used as the input to the predictions primitive.
-            If `None`, the output data reference to the pipeline's most recently added step will be used. 
-        """
-        if input_data_ref is None:
-            input_data_ref = pipeline_description.curr_step_data_ref
-        # PredictionsConstructor step
-        step = create_pipeline_step(
-            "d3m.primitives.data_transformation.construct_predictions.DataFrameCommon",
-            input_data_ref
-        )
-        step.add_argument(
-            name='reference',
-            argument_type=ArgumentType.CONTAINER,
-            data_reference=pipeline_description.data_ref_of('raw_df')
-        )
-        pipeline_description.add_step(step)
-
-    def _get_required_args(self, p: PrimitiveBase) -> list:
-        """
-        Gets the required arguments for a primitive
-        :param p: the primitive to get arguments for
-        :return a list of the required args
-        """
-        required_args = []
-        metadata_args = p.metadata.to_json_structure()['primitive_code']['arguments']
-        for arg, arg_info in metadata_args.items():
-            if 'default' not in arg_info and arg_info['kind'] == 'PIPELINE':  # If yes, it is a required argument
-                required_args.append(arg)
-        return required_args
-
-    def _generate_standard_pipeline(self, preprocessor: PrimitiveBase, classifier: PrimitiveBase) -> Pipeline:
-        """
-        Adds the crucial preprocess or classifier steps to a basic pipeline description and returns the pipeline
-        :param preprocessor: the primitive to use as a preprocessor
-        :param classifier: the primitive to use as a classifier
-        :return a newly created pipeline
-        """
-
-        # Creating Pipeline
-        pipeline_description = EZPipeline(context=Context.TESTING)
-
-        self._add_initial_steps(pipeline_description)
-        preprocessor_used = False
-
-        # Preprocessor Step
-        if preprocessor:
-            preprocessor_step = PrimitiveStep(primitive_description=preprocessor.metadata.query())
-            for arg in self._get_required_args(preprocessor):
-                if arg == "outputs":
-                    data_ref = pipeline_description.data_ref_of('target')
-                else:
-                    data_ref = pipeline_description.data_ref_of('attrs')
-                    preprocessor_used = True
-
-                preprocessor_step.add_argument(name=arg, argument_type=ArgumentType.CONTAINER,
-                                    data_reference=data_ref)
-            preprocessor_step.add_hyperparameter(name='use_semantic_types', argument_type=ArgumentType.VALUE, data=True)
-            preprocessor_step.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data="replace")
-            preprocessor_step.add_output('produce')
-            pipeline_description.add_step(preprocessor_step)
-
-        # Classifier Step
-        classifier_step = PrimitiveStep(primitive_description=classifier.metadata.query())
-        for arg in self._get_required_args(classifier):
-            if arg == "outputs":
-                data_ref = pipeline_description.data_ref_of('target')
-            else:
-                if preprocessor_used:
-                    data_ref = pipeline_description.curr_step_data_ref
-                else:
-                    data_ref = pipeline_description.data_ref_of('attrs')
-            classifier_step.add_argument(name=arg, argument_type=ArgumentType.CONTAINER,
-                                data_reference=data_ref)
-        classifier_step.add_hyperparameter(name='use_semantic_types', argument_type=ArgumentType.VALUE, data=True)
-        classifier_step.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data="replace")
-        classifier_step.add_output('produce')
-        pipeline_description.add_step(classifier_step)
-
-        self._add_predictions_constructor(pipeline_description)
-
-        # Adding output step to the pipeline
-        pipeline_description.add_output(name='Output', data_reference=pipeline_description.curr_step_data_ref)
-
-        return pipeline_description
 
     def get_possible_problems(self) -> dict:
         """
@@ -247,34 +127,6 @@ class Experimenter:
                 if problem_type in problems_list:
                     problems_list[problem_type].append(os.path.join(datasets_dir, dataset_name))
         return problems_list
-
-    def generate_pipelines(self, preprocessors: List[str], models: dict) -> dict:
-        """
-        A high level function to create numerous pipelines for a list of preprocessor and model
-        :param preprocessors: a list of preprocessors to generate pipelines with
-        :param models: a dict containing two keys of `classification` and `regression` each with a list of model primitive names
-        :return a dict containing two keys of `classification` and `regression` each a list of pipeline objects
-        """
-        preprocessors = list(set(preprocessors))
-
-        generated_pipelines = {"classification": [], "regression": []}
-        for type_name, model_list in models.items():
-            # Generate all pipelines without preprocessors
-            for model in model_list:
-                predictor: PrimitiveBase = d3m_index.get_primitive(model)
-                pipeline_without_preprocessor: Pipeline = self._generate_standard_pipeline(None, predictor)
-                generated_pipelines[type_name].append(pipeline_without_preprocessor)
-
-            # Generate all pipelines with preprocessors
-            for p in preprocessors:
-                preprocessor: PrimitiveBase = d3m_index.get_primitive(p)
-                for model in model_list:
-                    predictor: PrimitiveBase = d3m_index.get_primitive(model)
-
-                    pipeline_with_preprocessor: Pipeline = self._generate_standard_pipeline(preprocessor, predictor)
-                    generated_pipelines[type_name].append(pipeline_with_preprocessor)
-
-        return generated_pipelines
 
     def get_problem_type(self, problem_name: str, absolute_paths: List[str]):
         """
@@ -361,278 +213,6 @@ class Experimenter:
         logger.info("Results: {} pipelines added. {} pipelines already exist in database".format(added_pipeline_sum,
                                                                                            self.num_pipelines - added_pipeline_sum))
 
-    def _wrap_generate_all_ensembles(self, k_ensembles: int = 3, p_preprocessors: int = 1) -> dict:
-        """
-        This function does differing preprocessors and same model, or differing models and same preprocessor
-        It does NOT vary both.
-        :param k_ensembles: Number of sub-pipelines
-        :param p_preprocessors: Number of preprocessors per sub-pipeline
-        :return: a dict containing the ensemble pipelines
-        """
-        all_ensembles = {"classification": [], "regression": []}
-        preprocessor_combinations = list(combinations(self.preprocessors, p_preprocessors))
-
-        logger.info("Starting different models, same preprocessor")
-
-        # use K different models and the same preprocessor
-        for problem_type in self.models:
-            model_combinations = list(combinations(self.models[problem_type], k_ensembles))
-            for model_list in model_combinations:
-                for preprocessor in self.preprocessors:
-                    generated = self.generate_k_ensembles(k_ensembles=k_ensembles, p_preprocessors=p_preprocessors,
-                                                          given_preprocessors=[preprocessor], model=list(model_list),
-                                                          same_model=True, same_preprocessor_order=True,
-                                                          problem_type=problem_type)
-                    all_ensembles[problem_type] += generated[problem_type]
-
-        logger.info("Starting same models, different preprocessor")
-        # use the same model and a all possible combinations of K preprocessors
-        for problem_type in self.models:
-            for model in self.models[problem_type]:
-                for preprocessors in preprocessor_combinations:
-                    generated = self.generate_k_ensembles(k_ensembles=k_ensembles, p_preprocessors=p_preprocessors,
-                                                          given_preprocessors=preprocessors, model=model,
-                                                          same_model=True, same_preprocessor_order=True,
-                                                          problem_type=problem_type)
-                    all_ensembles[problem_type] += generated[problem_type]
-
-
-        return all_ensembles
-
-
-    def generate_k_ensembles(self, k_ensembles: int, p_preprocessors, n_generated_pipelines: int = 1, model: str = None,
-                             same_model: bool = True, same_preprocessor_order: bool = True,
-                             problem_type: str = "classification", given_preprocessors: list = None) -> dict:
-        """
-        This function takes all the options on how to generate ensembles and then returns the created pipelines
-        :param k_ensembles: the number of pipelines that will be ensembles together to form one big pipeline.
-        :param p_preprocessors: the number of preprocessors before each predictor in each sub-pipeline.
-        :param n_generated_pipelines: the number of pipelines to generate.
-        :param model: the specific model to use in the task.  This can be a string or a list of strings.
-        :param same_model: whether or not to use the same model every time as the predictor.
-        :param same_preprocessor_order: Whether or not to use the same preprocessor order every time
-        :param problem_type: whether to generate regression, classification, or both
-        :param given_preprocessors: a list of given preprocessors that you want to use
-        :return: a dictionary containing two keys "classification" and "regression" each containing the list of
-        generated pipelines
-        """
-
-        if model is None and same_model:
-            logger.info("Error: did not specify a model to ensemble with.  Please enter a valid model name.")
-            raise Exception
-
-        if k_ensembles == -1:
-            k_ensembles = min(len(model), len(preprocessors))
-
-        if problem_type == "all":
-            problem_types = ["classification", "regression"]
-        else:
-            problem_types = [problem_type]
-
-        # no point in generating the same pipeline twice (we were given a model and told to use the same order)
-        if model is not None and same_preprocessor_order:
-            n_generated_pipelines = 1
-
-        # initialize values and constants
-        generated_pipes = {'classification': [], 'regression': []}
-        model_list = []
-        preprocessor_list = []
-        vertical_concat = d3m_index.get_primitive("d3m.primitives.data_transformation.horizontal_concat.DataFrameConcat")
-        ensemble = d3m_index.get_primitive("d3m.primitives.classification.ensemble_voting.DSBOX")
-
-        for algorithm_type in problem_types:
-            # use the model given, or use random ones from all options
-            if model is None:
-                models_to_use = self.models[algorithm_type]
-            else:
-                models_to_use = model
-
-            # Create the pipelines
-            for _ in range(n_generated_pipelines):
-                if same_model:
-                    logger.info("Using the same model order")
-                    # is there only one model? If so use it all the time
-                    if type(models_to_use) == str or len(models_to_use) == 1:
-                        if type(models_to_use) == list:
-                            models_to_use = models_to_use[0]
-                        # Generate k pipelines with different preprocessors and the same model
-                        predictor: PrimitiveBase = d3m_index.get_primitive(models_to_use)
-                        model_list = [predictor] * k_ensembles
-                    else:
-                        # use the models given in exactly that order
-                        for index, algorithm in enumerate(models_to_use):
-                            if index == k_ensembles:
-                                break
-                            predictor: PrimitiveBase = d3m_index.get_primitive(algorithm)
-                            model_list.append(predictor)
-
-                else:
-                    logger.info("Randomly sampling models")
-                    # Generate k pipelines with randomly sampled models
-                    for index in range(len(models_to_use)):
-                        algorithm = sample(models_to_use, 1)[0]
-                        if index == k_ensembles:
-                            break
-                        predictor: PrimitiveBase = d3m_index.get_primitive(algorithm)
-                        model_list.append(predictor)
-
-                if same_preprocessor_order:
-                    logger.info("Using the same preprocessor order")
-                    # is there only one preprocessor? If so use it all the time
-                    if given_preprocessors is not None:
-                        if len(given_preprocessors) == 1:
-                            logger.info("Only given one preprocessor")
-                            preprocessor_to_use = given_preprocessors[0]
-                            preprocessor: PrimitiveBase = d3m_index.get_primitive(preprocessor_to_use)
-                            preprocessor_list = [[preprocessor] for x in range(k_ensembles)]
-                        else:
-                            logger.info("Only more than one preprocessor")
-                            # there is more than one preprocessor given
-                            for index, p in enumerate(given_preprocessors):
-                                preprocessor: PrimitiveBase = d3m_index.get_primitive(p)
-                                preprocessor_list.append([preprocessor])
-                    else:
-                        # this creates preprocessors with the same order every time
-                        for index, p in enumerate(self.preprocessors):
-                            if index == p_preprocessors:
-                                break
-                            preprocessor: PrimitiveBase = d3m_index.get_primitive(p)
-                            preprocessor_list.append([preprocessor])
-
-                else:
-                    logger.info("Randomly sampling preprocessors")
-                    # randomly sample preprocessors - til we have a new one for each model
-                    for index in range(k_ensembles):
-                        # get p preprocessor for each model
-                        pre = sample(preprocessors, p_preprocessors)
-                        if index == k_ensembles:
-                            break
-                        for p in pre:
-                            preprocessor: PrimitiveBase = d3m_index.get_primitive(p)
-                            preprocessor_list.append([preprocessor])
-                logger.info(model_list)
-                logger.info(preprocessor_list)
-                final_pipeline = self.create_ensemble_pipeline(k_ensembles, p_preprocessors, preprocessor_list,
-                                                               model_list, vertical_concat, ensemble)
-                generated_pipes[algorithm_type].append(final_pipeline)
-
-        return generated_pipes
-
-    def create_ensemble_pipeline(self, k: int, p: int, preprocessor_list: List[str], model_list: List[str], concatenator: PrimitiveBase, 
-                                 ensembler: PrimitiveBase) -> Pipeline:
-        """
-        This function does the nitty gritty work of preparing the pipeline and returning it
-        :param k: the number of pipelines that will be ensembled
-        :param p: the number of preprocessors for each sub-pipeline
-        :param preprocessor_list: a list of preprocessors to use
-        :param model_list:  the list of models to use
-        :param concatenator: the primitive that will concantentate the pipelines
-        :param ensembler: the ensembler that will ensemble all those pipelines together
-        :return: the ensembled pipeline
-        """
-
-        logger.info("Creating {} pipelines of length {}".format(k, p+1))
-        step_counter = 0
-
-        # Creating Pipeline
-        pipeline_description = EZPipeline(context=Context.TESTING)
-
-        self._add_initial_steps(pipeline_description)
-        list_of_outputs = []
-        preprocessor_used = False
-
-        # Add k pipelines
-        for pipeline_number in range(k):
-            # mod this in case we want repeats of the same model
-            model = model_list[pipeline_number % len(model_list)]
-
-            # Add Preprocessors Step
-            for index, pre in enumerate(reversed(preprocessor_list[pipeline_number % len(preprocessor_list)])):
-                if index == p:
-                    break
-                preprocessor_step = PrimitiveStep(primitive_description=pre.metadata.query())
-                for arg in self._get_required_args(pre):
-                    if arg == "outputs":
-                        data_ref = pipeline_description.data_ref_of('target')
-                    else:
-                        data_ref = pipeline_description.data_ref_of('attrs')
-                        preprocessor_used = True
-                    preprocessor_step.add_argument(name=arg, argument_type=ArgumentType.CONTAINER,
-                                        data_reference=data_ref)
-                preprocessor_step.add_hyperparameter(name='use_semantic_types', argument_type=ArgumentType.VALUE, data=True)
-                preprocessor_step.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data="replace")
-                preprocessor_step.add_output('produce')
-                pipeline_description.add_step(preprocessor_step)
-
-            # Classifier Step
-            classifier_step = PrimitiveStep(primitive_description=model.metadata.query())
-            for arg in self._get_required_args(model):
-                # if no preprocessors make sure we are getting the data from the imputer
-                if arg == "outputs":
-                    data_ref = pipeline_description.data_ref_of('target')
-                else:
-                    if preprocessor_used:
-                        data_ref = pipeline_description.curr_step_data_ref
-                    else:
-                        data_ref = pipeline_description.data_ref_of('attrs')
-                classifier_step.add_argument(name=arg, argument_type=ArgumentType.CONTAINER,
-                                    data_reference=data_ref)
-            classifier_step.add_hyperparameter(name='use_semantic_types', argument_type=ArgumentType.VALUE, data=True)
-            classifier_step.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data="replace")
-            classifier_step.add_hyperparameter(name='add_index_columns', argument_type=ArgumentType.VALUE, data=True)
-            classifier_step.add_output('produce')
-            pipeline_description.add_step(classifier_step)
-
-            self._add_predictions_constructor(pipeline_description)
-            list_of_outputs.append(pipeline_description.curr_step_data_ref)
-
-
-        # concatenate k - 1 times
-        for concat_num in range(k-1):
-            if concat_num == 0:
-                steps_data_ref_list = [list_of_outputs[concat_num], list_of_outputs[concat_num + 1]]
-            else:
-                steps_data_ref_list = [pipeline_description.curr_step_data_ref, list_of_outputs[concat_num + 1]]
-
-            concat_step = PrimitiveStep(primitive_description=concatenator.metadata.query())
-            for arg_index, arg in enumerate(self._get_required_args(concatenator)):
-                concat_step.add_argument(name=arg, argument_type=ArgumentType.CONTAINER,
-                                    data_reference=steps_data_ref_list[arg_index])
-            concat_step.add_output('produce')
-            pipeline_description.add_step(concat_step)
-
-
-        # finally ensemble them all together
-        renamer = PrimitiveStep(
-            primitive=d3m_index.get_primitive('d3m.primitives.data_transformation.rename_duplicate_name.DataFrameCommon'))
-        for arg_index, arg in enumerate(self._get_required_args(ensembler)):
-            renamer.add_argument(name=arg, argument_type=ArgumentType.CONTAINER,
-                                data_reference=pipeline_description.curr_step_data_ref)
-        renamer.add_output('produce')
-        pipeline_description.add_step(renamer)
-
-        # finally ensemble them all together TODO: change the RF to be dynamic
-        ensemble_model = d3m_index.get_primitive('d3m.primitives.regression.random_forest.SKlearn')
-        ensemble_step = PrimitiveStep(primitive_description=ensemble_model.metadata.query())
-        for arg_index, arg in enumerate(self._get_required_args(ensemble_model)):
-            if arg == "outputs":
-                ensemble_step.add_argument(name=arg, argument_type=ArgumentType.CONTAINER,
-                                    data_reference=pipeline_description.data_ref_of('target'))
-            else:
-                ensemble_step.add_argument(name=arg, argument_type=ArgumentType.CONTAINER,
-                                    data_reference=pipeline_description.curr_step_data_ref)
-        ensemble_step.add_output('produce')
-        pipeline_description.add_step(ensemble_step)
-
-        # output them as predictions
-        self._add_predictions_constructor(pipeline_description)
-
-        # Adding output step to the pipeline
-        pipeline_description.add_output(name='Output', data_reference=pipeline_description.curr_step_data_ref)
-
-        return pipeline_description
-
-
 
     def generate_default_pipeline(self) -> Pipeline:
         """
@@ -701,40 +281,6 @@ class Experimenter:
 
         # Output to YAML
         return {"classification": [pipeline_description], "regression": []}
-
-    def generate_metafeatures_pipeline(self) -> dict:
-        """
-        Generates the standard metafeature pipeline
-        """
-        # Creating pipeline
-        pipeline_description = EZPipeline(context=Context.TESTING)
-        pipeline_description.add_input(name='inputs')
-
-        # dataset_to_dataframe step
-        add_pipeline_step(
-            pipeline_description,
-            'd3m.primitives.data_transformation.dataset_to_dataframe.Common',
-            'inputs.0'
-        )
-
-        # column_parser step
-        add_pipeline_step(
-            pipeline_description,
-            'd3m.primitives.data_transformation.column_parser.DataFrameCommon'
-        )
-
-        # metafeature_extractor step
-        add_pipeline_step(
-            pipeline_description,
-            'd3m.primitives.metalearning.metafeature_extractor.BYU'
-        )
-
-        pipeline_description.add_output(name='output predictions', data_reference=pipeline_description.curr_step_data_ref)
-
-        with open("metafeature_extractor_pipeline.json", "w") as file:
-            json.dump(pipeline_description.to_json_structure(), file, indent=2, default=json_util.default)
-
-        return {"classification": [pipeline_description], "regression": [pipeline_description]}
 
 
 def _pretty_print_json(self, json_obj: str):

--- a/experimenter/experiments/ensemble.py
+++ b/experimenter/experiments/ensemble.py
@@ -1,0 +1,301 @@
+import logging
+logger = logging.getLogger(__name__)
+from typing import Dict, List
+from itertools import combinations
+from random import sample
+
+from d3m.metadata.pipeline import Pipeline, PrimitiveStep
+from d3m.primitive_interfaces.base import PrimitiveBase
+from d3m.metadata.base import Context, ArgumentType
+from d3m import index as d3m_index
+
+from experimenter.experiments.experiment import Experiment
+from experimenter.pipeline_builder import EZPipeline, add_initial_steps, get_required_args, add_predictions_constructor
+
+
+class EnsembleArchitectureExperimenter(Experiment):
+    """
+    Generates diverse pipelines with ensemble architectures.
+    """
+
+    def generate_pipelines(
+        self,
+        preprocessors: list,
+        models: Dict[str,str],
+        n_classifiers: int,
+        n_preprocessors: int
+    ) -> Dict[str, List[Pipeline]]:
+        """
+        This function does differing preprocessors and same model, or differing models and same preprocessor
+        It does NOT vary both.
+        :param preprocessors: List all of preprocessors that are available to use.
+        :param models: dictionary of all models that are available to use.
+        :param n_classifiers: Used to determine the number of sub-pipelines
+        :param n_preprocessors: Number of preprocessors per sub-pipeline
+        :return: a dict containing the ensemble pipelines
+        """
+        all_ensembles = {"classification": [], "regression": []}
+        preprocessor_combinations = list(combinations(preprocessors, n_preprocessors))
+
+        logger.info("Starting different models, same preprocessor")
+
+        # use K different models and the same preprocessor
+        for problem_type in models:
+            model_combinations = list(combinations(models[problem_type], n_classifiers))
+            for model_list in model_combinations:
+                for preprocessor in preprocessors:
+                    generated = self._generate_k_ensembles(k_ensembles=n_classifiers, n_preprocessors=n_preprocessors,
+                                                          preprocessors=preprocessors, models=models,
+                                                          given_preprocessors=[preprocessor], model=list(model_list),
+                                                          same_model=True, same_preprocessor_order=True,
+                                                          problem_type=problem_type)
+                    all_ensembles[problem_type] += generated[problem_type]
+
+        logger.info("Starting same models, different preprocessor")
+        # use the same model and a all possible combinations of K preprocessors
+        for problem_type in models:
+            for model in models[problem_type]:
+                for preprocessors in preprocessor_combinations:
+                    generated = self._generate_k_ensembles(k_ensembles=n_classifiers, n_preprocessors=n_preprocessors,
+                                                          preprocessors=preprocessors, models=models,
+                                                          given_preprocessors=preprocessors, model=model,
+                                                          same_model=True, same_preprocessor_order=True,
+                                                          problem_type=problem_type)
+                    all_ensembles[problem_type] += generated[problem_type]
+
+
+        return all_ensembles
+
+    def generate_pipeline(self, k: int, p: int, preprocessor_list: List[str], model_list: List[str], concatenator: PrimitiveBase, 
+                                 ensembler: PrimitiveBase) -> Pipeline:
+        """
+        This function does the nitty gritty work of preparing the pipeline and returning it
+        :param k: the number of pipelines that will be ensembled
+        :param p: the number of preprocessors for each sub-pipeline
+        :param preprocessor_list: a list of preprocessors to use
+        :param model_list:  the list of models to use
+        :param concatenator: the primitive that will concantentate the pipelines
+        :param ensembler: the ensembler that will ensemble all those pipelines together
+        :return: the ensembled pipeline
+        """
+
+        logger.info("Creating {} pipelines of length {}".format(k, p+1))
+
+        # Creating Pipeline
+        pipeline_description = EZPipeline(context=Context.TESTING)
+
+        add_initial_steps(pipeline_description)
+        list_of_outputs = []
+        preprocessor_used = False
+
+        # Add k pipelines
+        for pipeline_number in range(k):
+            # mod this in case we want repeats of the same model
+            model = model_list[pipeline_number % len(model_list)]
+
+            # Add Preprocessors Step
+            for index, pre in enumerate(reversed(preprocessor_list[pipeline_number % len(preprocessor_list)])):
+                if index == p:
+                    break
+                preprocessor_step = PrimitiveStep(primitive_description=pre.metadata.query())
+                for arg in get_required_args(pre):
+                    if arg == "outputs":
+                        data_ref = pipeline_description.data_ref_of('target')
+                    else:
+                        data_ref = pipeline_description.data_ref_of('attrs')
+                        preprocessor_used = True
+                    preprocessor_step.add_argument(name=arg, argument_type=ArgumentType.CONTAINER,
+                                        data_reference=data_ref)
+                preprocessor_step.add_hyperparameter(name='use_semantic_types', argument_type=ArgumentType.VALUE, data=True)
+                preprocessor_step.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data="replace")
+                preprocessor_step.add_output('produce')
+                pipeline_description.add_step(preprocessor_step)
+
+            # Classifier Step
+            classifier_step = PrimitiveStep(primitive_description=model.metadata.query())
+            for arg in get_required_args(model):
+                # if no preprocessors make sure we are getting the data from the imputer
+                if arg == "outputs":
+                    data_ref = pipeline_description.data_ref_of('target')
+                else:
+                    if preprocessor_used:
+                        data_ref = pipeline_description.curr_step_data_ref
+                    else:
+                        data_ref = pipeline_description.data_ref_of('attrs')
+                classifier_step.add_argument(name=arg, argument_type=ArgumentType.CONTAINER,
+                                    data_reference=data_ref)
+            classifier_step.add_hyperparameter(name='use_semantic_types', argument_type=ArgumentType.VALUE, data=True)
+            classifier_step.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data="replace")
+            classifier_step.add_hyperparameter(name='add_index_columns', argument_type=ArgumentType.VALUE, data=True)
+            classifier_step.add_output('produce')
+            pipeline_description.add_step(classifier_step)
+
+            add_predictions_constructor(pipeline_description)
+            list_of_outputs.append(pipeline_description.curr_step_data_ref)
+
+
+        # concatenate k - 1 times
+        for concat_num in range(k-1):
+            if concat_num == 0:
+                steps_data_ref_list = [list_of_outputs[concat_num], list_of_outputs[concat_num + 1]]
+            else:
+                steps_data_ref_list = [pipeline_description.curr_step_data_ref, list_of_outputs[concat_num + 1]]
+
+            concat_step = PrimitiveStep(primitive_description=concatenator.metadata.query())
+            for arg_index, arg in enumerate(get_required_args(concatenator)):
+                concat_step.add_argument(name=arg, argument_type=ArgumentType.CONTAINER,
+                                    data_reference=steps_data_ref_list[arg_index])
+            concat_step.add_output('produce')
+            pipeline_description.add_step(concat_step)
+
+
+        # finally ensemble them all together
+        renamer = PrimitiveStep(
+            primitive=d3m_index.get_primitive('d3m.primitives.data_transformation.rename_duplicate_name.DataFrameCommon'))
+        for arg_index, arg in enumerate(get_required_args(ensembler)):
+            renamer.add_argument(name=arg, argument_type=ArgumentType.CONTAINER,
+                                data_reference=pipeline_description.curr_step_data_ref)
+        renamer.add_output('produce')
+        pipeline_description.add_step(renamer)
+
+        # finally ensemble them all together TODO: change the RF to be dynamic
+        ensemble_model = d3m_index.get_primitive('d3m.primitives.regression.random_forest.SKlearn')
+        ensemble_step = PrimitiveStep(primitive_description=ensemble_model.metadata.query())
+        for arg_index, arg in enumerate(get_required_args(ensemble_model)):
+            if arg == "outputs":
+                ensemble_step.add_argument(name=arg, argument_type=ArgumentType.CONTAINER,
+                                    data_reference=pipeline_description.data_ref_of('target'))
+            else:
+                ensemble_step.add_argument(name=arg, argument_type=ArgumentType.CONTAINER,
+                                    data_reference=pipeline_description.curr_step_data_ref)
+        ensemble_step.add_output('produce')
+        pipeline_description.add_step(ensemble_step)
+
+        # output them as predictions
+        add_predictions_constructor(pipeline_description)
+
+        # Adding output step to the pipeline
+        pipeline_description.add_output(name='Output', data_reference=pipeline_description.curr_step_data_ref)
+
+        return pipeline_description
+
+    def _generate_k_ensembles(self, k_ensembles: int, n_preprocessors, preprocessors: list, models: dict,
+                             n_generated_pipelines: int = 1, model: str = None, same_model: bool = True,
+                             same_preprocessor_order: bool = True, problem_type: str = "classification",
+                             given_preprocessors: list = None) -> dict:
+        """
+        This function takes all the options on how to generate ensembles and then returns the created pipelines
+        :param k_ensembles: the number of pipelines that will be ensembles together to form one big pipeline.
+        :param n_preprocessors: the number of preprocessors before each predictor in each sub-pipeline.
+        :param preprocessors: List all of preprocessors that are available to use.
+        :param models: dictionary of all models that are available to use.
+        :param n_generated_pipelines: the number of pipelines to generate.
+        :param model: the specific model to use in the task.  This can be a string or a list of strings.
+        :param same_model: whether or not to use the same model every time as the predictor.
+        :param same_preprocessor_order: Whether or not to use the same preprocessor order every time
+        :param problem_type: whether to generate regression, classification, or both
+        :param given_preprocessors: a list of given preprocessors that you want to use
+        :return: a dictionary containing two keys "classification" and "regression" each containing the list of
+        generated pipelines
+        """
+
+        if model is None and same_model:
+            logger.info("Error: did not specify a model to ensemble with.  Please enter a valid model name.")
+            raise Exception
+
+        if k_ensembles == -1:
+            k_ensembles = min(len(model), len(preprocessors))
+
+        if problem_type == "all":
+            problem_types = ["classification", "regression"]
+        else:
+            problem_types = [problem_type]
+
+        # no point in generating the same pipeline twice (we were given a model and told to use the same order)
+        if model is not None and same_preprocessor_order:
+            n_generated_pipelines = 1
+
+        # initialize values and constants
+        generated_pipes = {'classification': [], 'regression': []}
+        model_list = []
+        preprocessor_list = []
+        vertical_concat = d3m_index.get_primitive("d3m.primitives.data_transformation.horizontal_concat.DataFrameConcat")
+        ensemble = d3m_index.get_primitive("d3m.primitives.classification.ensemble_voting.DSBOX")
+
+        for algorithm_type in problem_types:
+            # use the model given, or use random ones from all options
+            if model is None:
+                models_to_use = models[algorithm_type]
+            else:
+                models_to_use = model
+
+            # Create the pipelines
+            for _ in range(n_generated_pipelines):
+                if same_model:
+                    logger.info("Using the same model order")
+                    # is there only one model? If so use it all the time
+                    if type(models_to_use) == str or len(models_to_use) == 1:
+                        if type(models_to_use) == list:
+                            models_to_use = models_to_use[0]
+                        # Generate k pipelines with different preprocessors and the same model
+                        predictor: PrimitiveBase = d3m_index.get_primitive(models_to_use)
+                        model_list = [predictor] * k_ensembles
+                    else:
+                        # use the models given in exactly that order
+                        for index, algorithm in enumerate(models_to_use):
+                            if index == k_ensembles:
+                                break
+                            predictor: PrimitiveBase = d3m_index.get_primitive(algorithm)
+                            model_list.append(predictor)
+
+                else:
+                    logger.info("Randomly sampling models")
+                    # Generate k pipelines with randomly sampled models
+                    for index in range(len(models_to_use)):
+                        algorithm = sample(models_to_use, 1)[0]
+                        if index == k_ensembles:
+                            break
+                        predictor: PrimitiveBase = d3m_index.get_primitive(algorithm)
+                        model_list.append(predictor)
+
+                if same_preprocessor_order:
+                    logger.info("Using the same preprocessor order")
+                    # is there only one preprocessor? If so use it all the time
+                    if given_preprocessors is not None:
+                        if len(given_preprocessors) == 1:
+                            logger.info("Only given one preprocessor")
+                            preprocessor_to_use = given_preprocessors[0]
+                            preprocessor: PrimitiveBase = d3m_index.get_primitive(preprocessor_to_use)
+                            preprocessor_list = [[preprocessor] for x in range(k_ensembles)]
+                        else:
+                            logger.info("Only more than one preprocessor")
+                            # there is more than one preprocessor given
+                            for index, p in enumerate(given_preprocessors):
+                                preprocessor: PrimitiveBase = d3m_index.get_primitive(p)
+                                preprocessor_list.append([preprocessor])
+                    else:
+                        # this creates preprocessors with the same order every time
+                        for index, p in enumerate(preprocessors):
+                            if index == n_preprocessors:
+                                break
+                            preprocessor: PrimitiveBase = d3m_index.get_primitive(p)
+                            preprocessor_list.append([preprocessor])
+
+                else:
+                    logger.info("Randomly sampling preprocessors")
+                    # randomly sample preprocessors - til we have a new one for each model
+                    for index in range(k_ensembles):
+                        # get p preprocessor for each model
+                        pre = sample(preprocessors, n_preprocessors)
+                        if index == k_ensembles:
+                            break
+                        for p in pre:
+                            preprocessor: PrimitiveBase = d3m_index.get_primitive(p)
+                            preprocessor_list.append([preprocessor])
+                logger.info(model_list)
+                logger.info(preprocessor_list)
+                final_pipeline = self.generate_pipeline(k_ensembles, n_preprocessors, preprocessor_list,
+                                                               model_list, vertical_concat, ensemble)
+                generated_pipes[algorithm_type].append(final_pipeline)
+
+        return generated_pipes

--- a/experimenter/experiments/experiment.py
+++ b/experimenter/experiments/experiment.py
@@ -1,0 +1,29 @@
+from abc import ABC, abstractmethod
+from typing import Dict, List
+
+from d3m.metadata.pipeline import Pipeline
+
+class Experiment(ABC):
+    """
+    All experiments that are run by the `experimenter.experimenter`
+    module should inherit and implement this abstract class, so they
+    match the module's API.
+    """
+
+    @abstractmethod
+    def generate_pipelines(self) -> Dict[str, List[Pipeline]]:
+        """
+        Should return a mapping of problem type to a list of
+        pipelines outfitted for that problem type e.g.
+        `{"classification": [Pipeline()], "regression": [Pipeline()]}`.
+        Subclasses can define whatever input parameters they want.
+        """
+        pass
+    
+    @abstractmethod
+    def generate_pipeline(self) -> Pipeline:
+        """
+        Should generate a single pipeline
+        Subclasses can define whatever input parameters they want.
+        """
+        pass

--- a/experimenter/experiments/metafeatures.py
+++ b/experimenter/experiments/metafeatures.py
@@ -1,0 +1,53 @@
+from typing import Dict, List
+import json
+
+from d3m.metadata.pipeline import Pipeline
+from d3m.metadata.base import Context
+from bson import json_util
+
+from experimenter.experiments.experiment import Experiment
+from experimenter.pipeline_builder import EZPipeline, add_pipeline_step
+
+class MetafeatureExperimenter(Experiment):
+    """
+    Builds pipelines that will compute the metafeatures of
+    a dataset.
+    """
+
+    def generate_pipelines(self) -> Dict[str, List[Pipeline]]:
+        pipeline_description = self.generate_pipeline()
+        return {"classification": [pipeline_description], "regression": [pipeline_description]}
+    
+    def generate_pipeline(self) -> Pipeline:
+        """
+        Generates the standard metafeature pipeline
+        """
+        # Creating pipeline
+        pipeline_description = EZPipeline(context=Context.TESTING)
+        pipeline_description.add_input(name='inputs')
+
+        # dataset_to_dataframe step
+        add_pipeline_step(
+            pipeline_description,
+            'd3m.primitives.data_transformation.dataset_to_dataframe.Common',
+            'inputs.0'
+        )
+
+        # column_parser step
+        add_pipeline_step(
+            pipeline_description,
+            'd3m.primitives.data_transformation.column_parser.DataFrameCommon'
+        )
+
+        # metafeature_extractor step
+        add_pipeline_step(
+            pipeline_description,
+            'd3m.primitives.metalearning.metafeature_extractor.BYU'
+        )
+
+        pipeline_description.add_output(name='output predictions', data_reference=pipeline_description.curr_step_data_ref)
+
+        with open("metafeature_extractor_pipeline.json", "w") as file:
+            json.dump(pipeline_description.to_json_structure(), file, indent=2, default=json_util.default)
+        
+        return pipeline_description

--- a/experimenter/experiments/random.py
+++ b/experimenter/experiments/random.py
@@ -1,0 +1,22 @@
+from typing import Dict, List
+
+from d3m.metadata.pipeline import Pipeline
+
+from experimenter.experiments.experiment import Experiment
+
+class RandomArchitectureExperimenter(Experiment):
+    """
+    Generates diverse pipelines of random architectures.
+    """
+
+    def generate_pipelines(self) -> Dict[str, List[Pipeline]]:
+        """
+        TODO: Implement.
+        """
+        raise NotImplementedError
+    
+    def generate_pipeline(self) -> Pipeline:
+        """
+        TODO: Implement.
+        """
+        raise NotImplementedError

--- a/experimenter/experiments/stacked.py
+++ b/experimenter/experiments/stacked.py
@@ -1,0 +1,22 @@
+from typing import Dict, List
+
+from d3m.metadata.pipeline import Pipeline
+
+from experimenter.experiments.experiment import Experiment
+
+class StackedArchitectureExperimenter(Experiment):
+    """
+    Generates diverse pipelines of stacked architectures.
+    """
+
+    def generate_pipelines(self) -> Dict[str, List[Pipeline]]:
+        """
+        TODO: Implement.
+        """
+        raise NotImplementedError
+    
+    def generate_pipeline(self) -> Pipeline:
+        """
+        TODO: Implement.
+        """
+        raise NotImplementedError

--- a/experimenter/experiments/straight.py
+++ b/experimenter/experiments/straight.py
@@ -1,0 +1,101 @@
+from typing import Dict, List
+
+from d3m.metadata.pipeline import Pipeline, PrimitiveStep
+from d3m.primitive_interfaces.base import PrimitiveBase
+from d3m import index as d3m_index
+from d3m.metadata.base import Context, ArgumentType
+
+from experimenter.experiments.experiment import Experiment
+from experimenter.pipeline_builder import EZPipeline, add_initial_steps, get_required_args, add_predictions_constructor
+
+class StraightArchitectureExperimenter(Experiment):
+    """
+    Generates diverse pipelines of straight architectures.
+    """
+
+    def generate_pipelines(
+        self,
+        preprocessors: List[str],
+        models: Dict[str,str]
+    ) -> Dict[str, List[Pipeline]]:
+        """
+        A high level function to create numerous pipelines for a list of preprocessor and model
+        :param preprocessors: a list of preprocessors to generate pipelines with
+        :param models: a dict containing two keys of `classification` and `regression` each with a list of model primitive names
+        :return: a dict containing two keys of `classification` and `regression` each a list of pipeline objects
+        """
+        preprocessors = list(set(preprocessors))
+
+        generated_pipelines = {"classification": [], "regression": []}
+        for type_name, model_list in models.items():
+            # Generate all pipelines without preprocessors
+            for model in model_list:
+                predictor: PrimitiveBase = d3m_index.get_primitive(model)
+                pipeline_without_preprocessor: Pipeline = self.generate_pipeline(None, predictor)
+                generated_pipelines[type_name].append(pipeline_without_preprocessor)
+
+            # Generate all pipelines with preprocessors
+            for p in preprocessors:
+                preprocessor: PrimitiveBase = d3m_index.get_primitive(p)
+                for model in model_list:
+                    predictor: PrimitiveBase = d3m_index.get_primitive(model)
+
+                    pipeline_with_preprocessor: Pipeline = self.generate_pipeline(preprocessor, predictor)
+                    generated_pipelines[type_name].append(pipeline_with_preprocessor)
+
+        return generated_pipelines
+
+    def generate_pipeline(self, preprocessor: PrimitiveBase, classifier: PrimitiveBase) -> Pipeline:
+        """
+        Adds the crucial preprocess or classifier steps to a basic pipeline description and returns the pipeline
+        :param preprocessor: the primitive to use as a preprocessor
+        :param classifier: the primitive to use as a classifier
+        :return a newly created pipeline
+        """
+
+        # Creating Pipeline
+        pipeline_description = EZPipeline(context=Context.TESTING)
+
+        add_initial_steps(pipeline_description)
+        preprocessor_used = False
+
+        # Preprocessor Step
+        if preprocessor:
+            preprocessor_step = PrimitiveStep(primitive_description=preprocessor.metadata.query())
+            for arg in get_required_args(preprocessor):
+                if arg == "outputs":
+                    data_ref = pipeline_description.data_ref_of('target')
+                else:
+                    data_ref = pipeline_description.data_ref_of('attrs')
+                    preprocessor_used = True
+
+                preprocessor_step.add_argument(name=arg, argument_type=ArgumentType.CONTAINER,
+                                    data_reference=data_ref)
+            preprocessor_step.add_hyperparameter(name='use_semantic_types', argument_type=ArgumentType.VALUE, data=True)
+            preprocessor_step.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data="replace")
+            preprocessor_step.add_output('produce')
+            pipeline_description.add_step(preprocessor_step)
+
+        # Classifier Step
+        classifier_step = PrimitiveStep(primitive_description=classifier.metadata.query())
+        for arg in get_required_args(classifier):
+            if arg == "outputs":
+                data_ref = pipeline_description.data_ref_of('target')
+            else:
+                if preprocessor_used:
+                    data_ref = pipeline_description.curr_step_data_ref
+                else:
+                    data_ref = pipeline_description.data_ref_of('attrs')
+            classifier_step.add_argument(name=arg, argument_type=ArgumentType.CONTAINER,
+                                data_reference=data_ref)
+        classifier_step.add_hyperparameter(name='use_semantic_types', argument_type=ArgumentType.VALUE, data=True)
+        classifier_step.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data="replace")
+        classifier_step.add_output('produce')
+        pipeline_description.add_step(classifier_step)
+
+        add_predictions_constructor(pipeline_description)
+
+        # Adding output step to the pipeline
+        pipeline_description.add_output(name='Output', data_reference=pipeline_description.curr_step_data_ref)
+
+        return pipeline_description

--- a/experimenter/pipeline_builder.py
+++ b/experimenter/pipeline_builder.py
@@ -4,6 +4,7 @@ from d3m import index as d3m_index
 from d3m.metadata.pipeline import Pipeline
 from d3m.metadata.pipeline import PrimitiveStep
 from d3m.metadata.base import ArgumentType
+from d3m.primitive_interfaces.base import PrimitiveBase
 
 class EZPipeline(Pipeline):
     """
@@ -138,3 +139,88 @@ def add_pipeline_step(
         input_data_reference = pipeline_description.curr_step_data_ref
     step = create_pipeline_step(python_path, input_data_reference, **kwargs)
     pipeline_description.add_step(step)
+    
+
+def add_initial_steps(pipeline_description: EZPipeline) -> None:
+    """
+    :param pipeline_description: an empty pipeline object that we can add
+        the initial data preparation steps to.
+    """
+    # Creating pipeline
+    pipeline_description.add_input(name='inputs')
+
+    # dataset_to_dataframe step
+    add_pipeline_step(
+        pipeline_description,
+        'd3m.primitives.data_transformation.dataset_to_dataframe.Common',
+        'inputs.0'
+    )
+    pipeline_description.set_step_i_of('raw_df')
+
+    # column_parser step
+    add_pipeline_step(
+        pipeline_description,
+        'd3m.primitives.data_transformation.column_parser.DataFrameCommon'
+    )
+
+    # imputer step
+    add_pipeline_step(
+        pipeline_description,
+        'd3m.primitives.data_preprocessing.random_sampling_imputer.BYU'
+    )
+
+    # extract_columns_by_semantic_types(attributes) step
+    extract_attributes_step = create_pipeline_step(
+        'd3m.primitives.data_transformation.extract_columns_by_semantic_types.DataFrameCommon',
+        pipeline_description.curr_step_data_ref
+    )
+    extract_attributes_step.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE,
+                                data=['https://metadata.datadrivendiscovery.org/types/Attribute'])
+    pipeline_description.add_step(extract_attributes_step)
+    pipeline_description.set_step_i_of('attrs')
+
+    # extract_columns_by_semantic_types(targets) step
+    extract_targets_step = create_pipeline_step(
+        'd3m.primitives.data_transformation.extract_columns_by_semantic_types.DataFrameCommon',
+        pipeline_description.data_ref_of('raw_df')
+    )
+    extract_targets_step.add_hyperparameter(name='semantic_types', argument_type=ArgumentType.VALUE,
+                                data=['https://metadata.datadrivendiscovery.org/types/TrueTarget'])
+    pipeline_description.add_step(extract_targets_step)
+    pipeline_description.set_step_i_of('target')
+
+
+def add_predictions_constructor(pipeline_description: EZPipeline, input_data_ref: str = None) -> None:
+    """
+    Adds the predictions constructor to a pipeline description
+    :param pipeline_description: the pipeline-to-be
+    :param input_data_ref: the data reference to be used as the input to the predictions primitive.
+        If `None`, the output data reference to the pipeline's most recently added step will be used. 
+    """
+    if input_data_ref is None:
+        input_data_ref = pipeline_description.curr_step_data_ref
+    # PredictionsConstructor step
+    step = create_pipeline_step(
+        "d3m.primitives.data_transformation.construct_predictions.DataFrameCommon",
+        input_data_ref
+    )
+    step.add_argument(
+        name='reference',
+        argument_type=ArgumentType.CONTAINER,
+        data_reference=pipeline_description.data_ref_of('raw_df')
+    )
+    pipeline_description.add_step(step)
+
+
+def get_required_args(p: PrimitiveBase) -> list:
+    """
+    Gets the required arguments for a primitive
+    :param p: the primitive to get arguments for
+    :return a list of the required args
+    """
+    required_args = []
+    metadata_args = p.metadata.to_json_structure()['primitive_code']['arguments']
+    for arg, arg_info in metadata_args.items():
+        if 'default' not in arg_info and arg_info['kind'] == 'PIPELINE':  # If yes, it is a required argument
+            required_args.append(arg)
+    return required_args

--- a/experimenter_driver.py
+++ b/experimenter_driver.py
@@ -28,7 +28,8 @@ class ExperimenterDriver:
     """
 
     def __init__(self, datasets_dir: str, volumes_dir: str, run_type: str ="all",
-                 stored_pipeline_loc=None, distributed=False, generate_automl_pipelines=False, fit_only=False):
+                 stored_pipeline_loc=None, distributed=False, generate_automl_pipelines=False,
+                 fit_only=False, args: dict):
         self.datasets_dir = datasets_dir
         self.volumes_dir = volumes_dir
         self.run_type = run_type
@@ -112,13 +113,19 @@ class ExperimenterDriver:
             else:
                 pipes = self.get_pipelines_from_path(self.pipeline_location)
                 experimenter = Experimenter(self.datasets_dir, self.volumes_dir,
-                                            generate_pipelines=False, generate_problems=True)
+                                            generate_pipelines=False, generate_problems=True,
+                                            pipeline_gen_type=args.pipeline_gen_type,
+                                            n_classifiers=args.n_classifiers,
+                                            n_preprocessors=args.n_preprocessors)
                 problems = experimenter.problems
         # run type is pipelines from mongodb or "all"
         else:
             # generating the pipelines has already been taken care of
             experimenter = Experimenter(self.datasets_dir, self.volumes_dir,
-                                        generate_problems=True, generate_pipelines=False)
+                                        generate_problems=True, generate_pipelines=False
+                                        pipeline_gen_type=args.pipeline_gen_type,
+                                        n_classifiers=args.n_classifiers,
+                                        n_preprocessors=args.n_preprocessors)
             problems: dict = experimenter.problems
             if self.fit_only:
                 logger.info("Using only the fit pipeline")
@@ -213,12 +220,16 @@ def main(run_type: str, pipeline_folder: str, run_baselines: bool, only_run_fit:
         if run_type == "all":
             # Generate all possible problems and get pipelines - use default directory, classifiers, and preprocessors
             experimenter = Experimenter(datasets_dir, volumes_dir, generate_pipelines=True,
-                                        generate_problems=True, generate_automl_pipelines=run_baselines, args=args)
+                                        generate_problems=True, generate_automl_pipelines=run_baselines,
+                                        pipeline_gen_type=args.pipeline_gen_type, n_classifiers=args.n_classifiers,
+                                        n_preprocessors=args.n_preprocessors)
 
         elif run_type == "generate":
             logger.info("Only generating pipelines...")
             experimenter = Experimenter(datasets_dir, volumes_dir, generate_pipelines=True,
-                                        location=pipeline_folder, generate_automl_pipelines=run_baselines, args=args)
+                                        location=pipeline_folder, generate_automl_pipelines=run_baselines,
+                                        pipeline_gen_type=args.pipeline_gen_type, n_classifiers=args.n_classifiers,
+                                        n_preprocessors=args.n_preprocessors)
             return
 
         elif run_type == "distribute":

--- a/test/create_and_test.sh
+++ b/test/create_and_test.sh
@@ -10,11 +10,11 @@ sudo docker exec -it experimenter-test bash -c "pip3 install coverage"
 sudo docker exec -it experimenter-test bash -c "pip3 install codecov"
 sudo docker exec -it experimenter-test bash -c "export CODECOV_TOKEN='66edf814-d6e1-40ae-b98a-dfea63a7e197'"
 sudo docker exec -it experimenter-test bash -c "coverage run run_tests.py"
- sudo docker exec -it experimenter-test bash -c "bash <(curl -s https://codecov.io/bash)"
 val=$?
 if [ ${val} -ne  0 ]
 then
  echo "Tests did not pass"
  exit 1 
 fi
+sudo docker exec -it experimenter-test bash -c "bash <(curl -s https://codecov.io/bash)"
 rm -rf build/

--- a/test/test_ensembling_pipeline_runs.py
+++ b/test/test_ensembling_pipeline_runs.py
@@ -5,6 +5,7 @@ from experimenter.constants import models, preprocessors
 from d3m import runtime as runtime_module
 from d3m.metadata import pipeline as pipeline_module
 from experimenter.run_pipeline import RunPipeline
+from experimenter.experiments.ensemble import EnsembleArchitectureExperimenter
 
 
 def get_pipeline(
@@ -37,8 +38,7 @@ class TestEnsemblingPipelineRuns(unittest.TestCase):
         self.pipeline_path = './experimenter/pipelines/ensemble_test.json'
         self.data_pipeline_path = './experimenter/pipelines/fixed-split-tabular-split.yml'
         self.scoring_pipeline_path = './experimenter/pipelines/scoring.yml'
-        self.experiment = Experimenter(self.datasets_dir, self.volumes_dir, generate_pipelines=False,
-                                       generate_problems=False, generate_automl_pipelines=False)
+        self.experiment = EnsembleArchitectureExperimenter()
         self.preprocessors = preprocessors
         self.models = models
 
@@ -54,7 +54,9 @@ class TestEnsemblingPipelineRuns(unittest.TestCase):
         self.run_experimenter_from_pipeline(problem_path)
 
     def test_experimenter_run_works_and_generates_random(self):
-        generated_pipelines = self.experiment.generate_k_ensembles(k_ensembles=3, p_preprocessors=2,
+        generated_pipelines = self.experiment._generate_k_ensembles(k_ensembles=3, n_preprocessors=2,
+                                                                   preprocessors=preprocessors,
+                                                                   models=models,
                                                                    n_generated_pipelines=1, same_model=False,
                                                                    same_preprocessor_order=False,
                                                                    problem_type="classification")
@@ -64,7 +66,9 @@ class TestEnsemblingPipelineRuns(unittest.TestCase):
 
     def test_experimenter_run_works_and_generates_fixed(self):
         model = "d3m.primitives.classification.random_forest.SKlearn"
-        generated_pipelines = self.experiment.generate_k_ensembles(k_ensembles=3, p_preprocessors=2,
+        generated_pipelines = self.experiment._generate_k_ensembles(k_ensembles=3, n_preprocessors=2,
+                                                                   preprocessors=preprocessors,
+                                                                   models=models,
                                                                    n_generated_pipelines=1, same_model=True,
                                                                    same_preprocessor_order=False,
                                                                    problem_type="classification",
@@ -74,7 +78,9 @@ class TestEnsemblingPipelineRuns(unittest.TestCase):
         self.run_experimenter_from_pipeline(problem_path, pipeline_to_run)
 
     def test_experimenter_run_works_and_generates_LARGE(self):
-        generated_pipelines = self.experiment.generate_k_ensembles(k_ensembles=6, p_preprocessors=4,
+        generated_pipelines = self.experiment._generate_k_ensembles(k_ensembles=6, n_preprocessors=4,
+                                                                   preprocessors=preprocessors,
+                                                                   models=models,
                                                                    n_generated_pipelines=1, same_model=False,
                                                                    same_preprocessor_order=False,
                                                                    problem_type="classification")

--- a/test/test_ensembling_pipelines_generation.py
+++ b/test/test_ensembling_pipelines_generation.py
@@ -1,7 +1,9 @@
 import unittest
+from experimenter.constants import models, preprocessors
 from experimenter.experimenter import *
 from experimenter.database_communication import primitive_list_from_pipeline_json
 from experimenter.constants import models, preprocessors
+from experimenter.experiments.ensemble import EnsembleArchitectureExperimenter
 
 
 class TestEnsemblingPipelinesGeneration(unittest.TestCase):
@@ -15,8 +17,7 @@ class TestEnsemblingPipelinesGeneration(unittest.TestCase):
         self.data_pipeline_path = './experimenter/pipelines/fixed-split-tabular-split.yml'
         self.scoring_pipeline_path = './experimenter/pipelines/scoring.yml'
         # initialize the experimenter
-        self.experiment = Experimenter(self.datasets_dir, self.volumes_dir, generate_pipelines=False,
-                                  generate_problems=False, generate_automl_pipelines=False)
+        self.experiment = EnsembleArchitectureExperimenter()
         self.preprocessors = preprocessors
         self.models = models
 
@@ -29,7 +30,9 @@ class TestEnsemblingPipelinesGeneration(unittest.TestCase):
 
     def test_experimenter_can_generate_basic(self):
         # generate the pipelines
-        generated_pipelines = self.experiment.generate_k_ensembles(k_ensembles=3, p_preprocessors=1,
+        generated_pipelines = self.experiment._generate_k_ensembles(k_ensembles=3, n_preprocessors=1,
+                                                                        preprocessors=preprocessors,
+                                                                        models=models,
                                                                         n_generated_pipelines=1, same_model=False,
                                                                         same_preprocessor_order=False,
                                                                         problem_type="classification")
@@ -39,7 +42,9 @@ class TestEnsemblingPipelinesGeneration(unittest.TestCase):
 
     def test_experimenter_can_generate_all_types(self):
         # generate the pipelines
-        generated_pipelines = self.experiment.generate_k_ensembles(k_ensembles=3, p_preprocessors=1,
+        generated_pipelines = self.experiment._generate_k_ensembles(k_ensembles=3, n_preprocessors=1,
+                                                                        preprocessors=preprocessors,
+                                                                        models=models,
                                                                         n_generated_pipelines=1, same_model=False,
                                                                         same_preprocessor_order=False,
                                                                         problem_type="all")
@@ -52,7 +57,9 @@ class TestEnsemblingPipelinesGeneration(unittest.TestCase):
 
     def test_experimenter_can_generate_multiples(self):
         # generate the pipelines
-        generated_pipelines = self.experiment.generate_k_ensembles(k_ensembles=3, p_preprocessors=1,
+        generated_pipelines = self.experiment._generate_k_ensembles(k_ensembles=3, n_preprocessors=1,
+                                                                        preprocessors=preprocessors,
+                                                                        models=models,
                                                                         n_generated_pipelines=10, same_model=False,
                                                                         same_preprocessor_order=False,
                                                                         problem_type="classification")
@@ -66,7 +73,9 @@ class TestEnsemblingPipelinesGeneration(unittest.TestCase):
     #     num_preprocessors = 5
     #     num_ensembles = 3
     #     # generate the pipelines
-    #     generated_pipelines = self.experiment.generate_k_ensembles(k_ensembles=num_ensembles, p_preprocessors=num_preprocessors,
+    #     generated_pipelines = self.experiment._generate_k_ensembles(k_ensembles=num_ensembles, n_preprocessors=num_preprocessors,
+    #                                                                     preprocessors=preprocessors,
+    #                                                                     models=models,
     #                                                                     n_generated_pipelines=1, same_model=False,
     #                                                                     same_preprocessor_order=True,
     #                                                                     problem_type="classification")
@@ -86,7 +95,9 @@ class TestEnsemblingPipelinesGeneration(unittest.TestCase):
         """
         num_models = 5
         # generate the pipelines
-        generated_pipelines = self.experiment.generate_k_ensembles(k_ensembles=num_models, p_preprocessors=1,
+        generated_pipelines = self.experiment._generate_k_ensembles(k_ensembles=num_models, n_preprocessors=1,
+                                                                   preprocessors=preprocessors,
+                                                                   models=models,
                                                                    n_generated_pipelines=1, same_model=False,
                                                                    same_preprocessor_order=True,
                                                                    problem_type="classification")
@@ -105,7 +116,9 @@ class TestEnsemblingPipelinesGeneration(unittest.TestCase):
     def test_experimenter_can_generate_same_models(self):
         num_models = 5
         # generate the pipelines
-        generated_pipelines = self.experiment.generate_k_ensembles(k_ensembles=num_models, p_preprocessors=1,
+        generated_pipelines = self.experiment._generate_k_ensembles(k_ensembles=num_models, n_preprocessors=1,
+                                                                   preprocessors=preprocessors,
+                                                                   models=models,
                                                                    n_generated_pipelines=1, same_model=True,
                                                                    same_preprocessor_order=True,
                                                                    model="d3m.primitives.classification.random_forest.SKlearn",
@@ -125,7 +138,9 @@ class TestEnsemblingPipelinesGeneration(unittest.TestCase):
     def test_experimenter_has_correct_input(self):
         # Should fail
         try:
-            generated_pipelines = self.experiment.generate_k_ensembles(k_ensembles=3, p_preprocessors=1,
+            generated_pipelines = self.experiment._generate_k_ensembles(k_ensembles=3, n_preprocessors=1,
+                                                                       preprocessors=preprocessors,
+                                                                       models=models,
                                                                        n_generated_pipelines=10, same_model=True,
                                                                        same_preprocessor_order=False,
                                                                        problem_type="classification")
@@ -136,7 +151,9 @@ class TestEnsemblingPipelinesGeneration(unittest.TestCase):
     def test_experimenter_has_correct_input_model_length(self):
         # Should fail
         try:
-            generated_pipelines = self.experiment.generate_k_ensembles(k_ensembles=3, p_preprocessors=1,
+            generated_pipelines = self.experiment._generate_k_ensembles(k_ensembles=3, n_preprocessors=1,
+                                                                       preprocessors=preprocessors,
+                                                                       models=models,
                                                                        n_generated_pipelines=10, same_model=True,
                                                                        same_preprocessor_order=False,
                                                                        problem_type="classification",

--- a/test/test_pipeline_generator.py
+++ b/test/test_pipeline_generator.py
@@ -19,8 +19,10 @@ class PipelineGenerationTestCase(unittest.TestCase):
         preprocessors = []  # give no preprocessors
         self.experimenter_driver = Experimenter(
             self.datasets_dir, volumes_dir,
-            self.seed_problem_directory, models, preprocessors,
-            generate_problems=True
+            input_problem_directory=self.seed_problem_directory,
+            input_models=models,
+            input_preprocessors=preprocessors,
+            generate_problems=True,
         )
 
     def test_get_classification_problems(self):


### PR DESCRIPTION
- Factored out the code for each separate experiment (ensemble, straight, metafeatures, etc.) from `experimenter.py` into its own module.
- Decoupled the `Experimenter` class from needing to be passed command line arguments, to avoid the need for dependency injection when testing.
- Renamed a couple methods so the experiments would all fit the requirements of the `Experiment` abstract parent class.
- Added stub class for the stacked and random pipeline experiments.