### PR TITLE
Track arch type

### DIFF
--- a/experimenter/database_communication.py
+++ b/experimenter/database_communication.py
@@ -204,8 +204,7 @@ class PipelineDB:
         :return False if the database already contains it, True if the pipeline was added to the database
         """
         db = self.mongo_client.metalearning
-        pipeline_collection = db.pipelines
-        pipeline_arch_desc_collection = db.arch_descs
+        collection = db.pipelines
         new_pipeline_json = new_pipeline.to_json_structure()
         digest = new_pipeline_json["digest"]
         id = new_pipeline_json["id"]
@@ -214,14 +213,14 @@ class PipelineDB:
         new_pipeline.check()
 
         # simple checks to validate pipelines and potentially save time
-        if pipeline_collection.find({"digest": digest}).count():
+        if collection.find({"digest": digest}).count():
             return False
 
-        if pipeline_collection.find({"id": id}).count():
+        if collection.find({"id": id}).count():
             return False
         #
         # # deep comparison of equality
-        # pipelines_cursor = pipeline_collection.find({})
+        # pipelines_cursor = collection.find({})
         # for index, pipeline in enumerate(pipelines_cursor):
         #     try:
         #         # forgo this for now until we can get it to work.
@@ -237,10 +236,7 @@ class PipelineDB:
         #         raise(e)
         #
         # else:
-        pipeline_id = pipeline_collection.insert_one(new_pipeline_json).inserted_id
-        if new_pipeline.arch_desc is not None:
-            arch_desc_json_structure = new_pipeline.arch_desc.to_json_structure(digest)
-            pipeline_arch_desc_collection.insert_one(arch_desc_json_structure)
+        pipeline_id = collection.insert_one(new_pipeline_json).inserted_id
         logger.info("Wrote pipeline to the database with inserted_id from mongo: {}".format(pipeline_id))
         return True
 

--- a/experimenter/experiments/ensemble.py
+++ b/experimenter/experiments/ensemble.py
@@ -10,7 +10,10 @@ from d3m.metadata.base import Context, ArgumentType
 from d3m import index as d3m_index
 
 from experimenter.experiments.experiment import Experiment
-from experimenter.pipeline_builder import EZPipeline, map_pipeline_step_arguments, add_initial_steps, get_required_args, add_predictions_constructor
+from experimenter.pipeline_builder import (
+    EZPipeline, PipelineArchDesc, map_pipeline_step_arguments, add_initial_steps, get_required_args, add_predictions_constructor
+)
+
 
 class EnsembleArchitectureExperimenter(Experiment):
     """
@@ -81,7 +84,11 @@ class EnsembleArchitectureExperimenter(Experiment):
         logger.info("Creating {} pipelines of length {}".format(k, p+1))
 
         # Creating Pipeline
-        pipeline_description = EZPipeline(context=Context.TESTING)
+        architecture = PipelineArchDesc(
+            "ensemble",
+            { "width": k, "subpipeline_length": p+1 }
+        )
+        pipeline_description = EZPipeline(arch_desc=architecture, context=Context.TESTING)
 
         add_initial_steps(pipeline_description)
         list_of_outputs = []

--- a/experimenter/experiments/metafeatures.py
+++ b/experimenter/experiments/metafeatures.py
@@ -6,7 +6,7 @@ from d3m.metadata.base import Context
 from bson import json_util
 
 from experimenter.experiments.experiment import Experiment
-from experimenter.pipeline_builder import EZPipeline, add_pipeline_step
+from experimenter.pipeline_builder import EZPipeline, PipelineArchDesc, add_pipeline_step
 
 class MetafeatureExperimenter(Experiment):
     """
@@ -23,7 +23,8 @@ class MetafeatureExperimenter(Experiment):
         Generates the standard metafeature pipeline
         """
         # Creating pipeline
-        pipeline_description = EZPipeline(context=Context.TESTING)
+        architecture = PipelineArchDesc("metafeatures")
+        pipeline_description = EZPipeline(arch_desc=architecture, context=Context.TESTING)
         pipeline_description.add_input(name='inputs')
 
         # dataset_to_dataframe step

--- a/experimenter/experiments/straight.py
+++ b/experimenter/experiments/straight.py
@@ -6,7 +6,9 @@ from d3m import index as d3m_index
 from d3m.metadata.base import Context, ArgumentType
 
 from experimenter.experiments.experiment import Experiment
-from experimenter.pipeline_builder import EZPipeline, map_pipeline_step_arguments, add_initial_steps, get_required_args, add_predictions_constructor
+from experimenter.pipeline_builder import (
+    EZPipeline, PipelineArchDesc, map_pipeline_step_arguments, add_initial_steps, get_required_args, add_predictions_constructor
+)
 
 class StraightArchitectureExperimenter(Experiment):
     """
@@ -54,7 +56,8 @@ class StraightArchitectureExperimenter(Experiment):
         """
 
         # Creating Pipeline
-        pipeline_description = EZPipeline(context=Context.TESTING)
+        architecture = PipelineArchDesc("straight")
+        pipeline_description = EZPipeline(arch_desc=architecture, context=Context.TESTING)
 
         add_initial_steps(pipeline_description)
         preprocessor_used = False
@@ -73,6 +76,8 @@ class StraightArchitectureExperimenter(Experiment):
                 req_args
             )
             pipeline_description.add_step(preprocessor_step)
+        
+        pipeline_description.arch_desc.attributes["preprocessor_used"] = preprocessor_used
 
         # Classifier Step
         classifier_step = PrimitiveStep(primitive_description=classifier.metadata.query())

--- a/experimenter/experiments/straight.py
+++ b/experimenter/experiments/straight.py
@@ -65,7 +65,7 @@ class StraightArchitectureExperimenter(Experiment):
         # Preprocessor Step
         if preprocessor:
             preprocessor_step = PrimitiveStep(primitive_description=preprocessor.metadata.query())
-            req_args = get_required_args(pre)
+            req_args = get_required_args(preprocessor)
             for arg in req_args:
                 if arg != "outputs":
                     preprocessor_used = True
@@ -77,7 +77,7 @@ class StraightArchitectureExperimenter(Experiment):
             )
             pipeline_description.add_step(preprocessor_step)
         
-        pipeline_description.arch_desc.attributes["preprocessor_used"] = preprocessor_used
+        pipeline_description.arch_desc.generation_parameters["preprocessor_used"] = preprocessor_used
 
         # Classifier Step
         classifier_step = PrimitiveStep(primitive_description=classifier.metadata.query())

--- a/experimenter/pipeline_builder.py
+++ b/experimenter/pipeline_builder.py
@@ -1,6 +1,6 @@
 from typing import Tuple, List, Any, Dict
 
-from d3m import index as d3m_index
+from d3m import utils as d3m_utils, index as d3m_index
 from d3m.metadata.pipeline import Pipeline
 from d3m.metadata.pipeline import PrimitiveStep
 from d3m.metadata.base import ArgumentType
@@ -12,33 +12,26 @@ from experimenter.constants import EXTRA_HYPEREPARAMETERS
 class PipelineArchDesc:
     """
     Holds data that describes a pipeline's architecture. e.g.
-    `PipelineArchDesc(pipeline_type="ensemble", attributes={"k": 3}) could
+    `PipelineArchDesc(generation_method="ensemble", generation_parameters={"k": 3}) could
     describe an ensemble pipeline that ensembles three classifiers.
     """
 
-    def __init__(self, pipeline_type: str, attributes: Dict[str, Any] = None):
+    def __init__(self, generation_method: str, generation_parameters: Dict[str, Any] = None):
         """
-        :param pipeline_type: The pipeline's high level structural type e.g.
+        :param generation_method: The pipeline's high level structural type e.g.
             "ensemble", "straight", "random", etc.
-        :param attributes: An optional dictionary holding data describing
+        :param generation_parameters: An optional dictionary holding data describing
             attributes of the pipeline's architecture e.g.
             { "depth": 4, "max_width": 3 }, etc. Fields in the dictionary
             will likely vary depending on the pipeline's type.
         """
-        self.pipeline_type = pipeline_type
-        self.attributes = dict() if attributes is None else attributes
+        self.generation_method = generation_method
+        self.generation_parameters = dict() if generation_parameters is None else generation_parameters
     
-    def to_json_structure(self, pipeline_digest: str):
-        """
-        :param pipeline_digest: An instance of `PipelineArchDesc` should
-        always be associated with a pipeline. That pipeline is identified
-        by the `pipeline_digest` parameter.
-        """
-        assert pipeline_digest is not None
+    def to_json_structure(self):
         return {
-            "pipeline_digest": pipeline_digest,
-            "pipeline_type": self.pipeline_type,
-            "attributes": self.attributes
+            "generation_method": self.generation_method,
+            "generation_parameters": self.generation_parameters
         }
 
 
@@ -103,8 +96,8 @@ class EZPipeline(Pipeline):
             self._step_i_of_refs[ref_name] = self.curr_step_i
         else:
             self._step_i_of_refs[ref_name] = step_i
-            
     
+
     def data_ref_of(self, ref_name: str) -> str:
         """
         Returns a data reference to the output of the step associated
@@ -117,6 +110,20 @@ class EZPipeline(Pipeline):
         if ref_step_i is None:
             raise ValueError(f'{ref_name} has not been set yet')
         return self._data_ref_by_step_i(ref_step_i)
+    
+    def to_json_structure(self, *args, **kwargs) -> Dict:
+        """
+        An overriden version of the parent class `Pipeline`'s method.
+        Adds the pipeline architecture description to the json.
+        """
+        pipeline_json = super().to_json_structure(*args, **kwargs)
+        if self.arch_desc is not None:
+            pipeline_json['pipeline_generation_description'] = self.arch_desc.to_json_structure()
+            # Update the digest since new information has been added to the description
+            pipeline_json['digest'] = d3m_utils.compute_digest(pipeline_json)
+        
+        return pipeline_json
+
     
     # Private methods
     

--- a/experimenter_driver.py
+++ b/experimenter_driver.py
@@ -252,7 +252,7 @@ if __name__ == "__main__":
     parser.add_argument("--run-custom-fit", '-c', help="Whether or not to run only fit and use given pipelines",
                         action='store_true')
     parser.add_argument("--pipeline-gen-type", '-p', help="what type of pipelines to generate: ensembles, straight, metafeature, or random",
-                        choices=["ensemble", "straight", "metafeatures", "random"], default="straight")
+                        choices=["ensemble", "straight", "metafeatures", "random", "stacked"], default="straight")
     parser.add_argument("--verbose", "-v", action="store_true", help="Whether to print for debugging or not", default=False)
     parser.add_argument("--n_preprocessors", "-np", type=int, help="how many preprocessors to use for generation", default=3)
     parser.add_argument("--n_classifiers", "-nc", type=int, help="how many classifiers to use for generation", default=3)

--- a/test/test_pipeline_builder.py
+++ b/test/test_pipeline_builder.py
@@ -3,7 +3,9 @@ import unittest
 
 from d3m.metadata.base import Context, ArgumentType
 
-from experimenter.pipeline_builder import EZPipeline, create_pipeline_step, add_pipeline_step
+from experimenter.pipeline_builder import (
+    EZPipeline, PipelineArchDesc, create_pipeline_step, add_pipeline_step
+)
 
 
 class PipelineGenerationTestCase(unittest.TestCase):
@@ -61,7 +63,27 @@ class PipelineGenerationTestCase(unittest.TestCase):
         pipeline.set_step_i_of('attrs')
 
         json_rep = pipeline.to_json_structure()
-        self.assertEqual(len(json_rep["steps"]), 3)
+        self.assertEqual(len(json_rep['steps']), 3)
+    
+    def test_arch_desc(self) -> None:
+        architecture = PipelineArchDesc('test', { 'test_attr': None })
+        pipeline = EZPipeline(arch_desc=architecture, context=Context.TESTING)
+
+        # The json form of arch_desc requires a pipeline digest
+        with self.assertRaises(Exception):
+            pipeline.arch_desc.to_json_structure(None)
+        
+        # An architecture description should be able to be altered
+        # once created
+        pipeline.arch_desc.attributes['other_test_attr'] = 'abc'
+
+        # The json form of arch_desc should be complete
+        fake_digest = '1'
+        arch_desc_json = pipeline.arch_desc.to_json_structure(fake_digest)
+
+        self.assertIn('test_attr', arch_desc_json['attributes'])
+        self.assertIsNone(arch_desc_json['attributes']['test_attr'])
+        self.assertEqual(arch_desc_json['attributes']['other_test_attr'], 'abc')
         
     # Private methods
 

--- a/test/test_pipeline_builder.py
+++ b/test/test_pipeline_builder.py
@@ -2,6 +2,7 @@ import sys
 import unittest
 
 from d3m.metadata.base import Context, ArgumentType
+import d3m.utils as d3m_utils
 
 from experimenter.pipeline_builder import (
     EZPipeline, PipelineArchDesc, create_pipeline_step, add_pipeline_step
@@ -68,22 +69,32 @@ class PipelineGenerationTestCase(unittest.TestCase):
     def test_arch_desc(self) -> None:
         architecture = PipelineArchDesc('test', { 'test_attr': None })
         pipeline = EZPipeline(arch_desc=architecture, context=Context.TESTING)
-
-        # The json form of arch_desc requires a pipeline digest
-        with self.assertRaises(Exception):
-            pipeline.arch_desc.to_json_structure(None)
+        pipeline.add_input(name='inputs')
+        self._add_dataset_to_df_step(pipeline)
         
         # An architecture description should be able to be altered
         # once created
-        pipeline.arch_desc.attributes['other_test_attr'] = 'abc'
+        pipeline.arch_desc.generation_parameters['other_test_attr'] = 'abc'
 
-        # The json form of arch_desc should be complete
-        fake_digest = '1'
-        arch_desc_json = pipeline.arch_desc.to_json_structure(fake_digest)
+        # Pipeline should be valid in D3M's eyes, even with the custom
+        # architecture description fields
+        try:
+            pipeline.check()
+        except Exception as e:
+            self.fail(f'pipeline is not a valid d3m pipeline: {repr(e)}')
 
-        self.assertIn('test_attr', arch_desc_json['attributes'])
-        self.assertIsNone(arch_desc_json['attributes']['test_attr'])
-        self.assertEqual(arch_desc_json['attributes']['other_test_attr'], 'abc')
+        # The pipeline json should include the architecture description added above
+        pipeline_json = pipeline.to_json_structure()
+        self.assertIn('steps', pipeline_json)
+        self.assertIn('pipeline_generation_description', pipeline_json)
+
+        arch_desc_json = pipeline_json['pipeline_generation_description']
+        self.assertIn('test_attr', arch_desc_json['generation_parameters'])
+        self.assertIsNone(arch_desc_json['generation_parameters']['test_attr'])
+        self.assertEqual(arch_desc_json['generation_parameters']['other_test_attr'], 'abc')
+
+        # The pipeline's digest should be correct
+        self.assertEqual(pipeline_json['digest'], d3m_utils.compute_digest(pipeline_json))
         
     # Private methods
 


### PR DESCRIPTION
Closes #58.

Adds data to a pipeline json representation about how a pipeline was generated. Adds the data in a D3M-compliant way.