### PR TITLE
Add Random Experiment

### DIFF
--- a/experimenter/constants.py
+++ b/experimenter/constants.py
@@ -68,6 +68,12 @@ models = {
         # "d3m.primitives.regression.sgd.SKlearn",
     ]
 }
+
+# All primitives that need more than one column as input
+primitives_needing_gt_one_column = {
+    "d3m.primitives.feature_selection.select_percentile.SKlearn"
+}
+
 problem_directories = [
     "seed_datasets_current/",
     "training_datasets/LL0/",
@@ -77,17 +83,17 @@ problem_directories = [
 EXTRA_HYPEREPARAMETERS = {
     "d3m.primitives.feature_extraction.kernel_pca.SKlearn": [
         {
-        "name": "kernel",
+            "name": "kernel",
             "type": ArgumentType.VALUE,
             "data": "rbf"
         }
     ],
     "d3m.primitives.feature_selection.generic_univariate_select.SKlearn": [
         {
-        "name": "mode",
+            "name": "mode",
             "type": ArgumentType.VALUE,
             "data": "fpr"
-    },
+        },
         {
             "name": "param",
             "type": ArgumentType.VALUE,

--- a/experimenter/constants.py
+++ b/experimenter/constants.py
@@ -1,3 +1,5 @@
+from d3m.metadata.base import ArgumentType
+
 preprocessors = [
     "d3m.primitives.data_preprocessing.standard_scaler.SKlearn",
     "d3m.primitives.feature_selection.generic_univariate_select.SKlearn",
@@ -73,16 +75,25 @@ problem_directories = [
 ]
 
 EXTRA_HYPEREPARAMETERS = {
-    "d3m.primitives.feature_extraction.kernel_pca.SKlearn": {
+    "d3m.primitives.feature_extraction.kernel_pca.SKlearn": [
+        {
         "name": "kernel",
-        "type": "ArgumentType.VALUE",
-        "data": "sigmoid"
-    },
-    "d3m.primitives.feature_selection.generic_univariate_select.SKlearn": {
+            "type": ArgumentType.VALUE,
+            "data": "rbf"
+        }
+    ],
+    "d3m.primitives.feature_selection.generic_univariate_select.SKlearn": [
+        {
         "name": "mode",
-        "type": "ArgumentType.VALUE",
-        "data": "k_best"
+            "type": ArgumentType.VALUE,
+            "data": "fpr"
     },
+        {
+            "name": "param",
+            "type": ArgumentType.VALUE,
+            "data": 0.05
+        }
+    ],
 }
 
 blacklist_non_tabular_data = [

--- a/experimenter/constants.py
+++ b/experimenter/constants.py
@@ -1,18 +1,32 @@
 from d3m.metadata.base import ArgumentType
 
-preprocessors = [
-    "d3m.primitives.data_preprocessing.standard_scaler.SKlearn",
-    "d3m.primitives.feature_selection.generic_univariate_select.SKlearn",
-    "d3m.primitives.feature_extraction.kernel_pca.SKlearn",
-    "d3m.primitives.feature_extraction.pca.SKlearn",
+# It is ok to use these temperamental preprocessors in production because
+# we're ok with some pipelines degenerating on some datasets.
+temperamental_preprocessors = [
+    # Note: These primitives return an empty DF when the data doesn't
+    # have enough signal:
     "d3m.primitives.feature_selection.select_fwe.SKlearn",
+    "d3m.primitives.feature_selection.generic_univariate_select.SKlearn",
     "d3m.primitives.feature_selection.select_percentile.SKlearn",
+    "d3m.primitives.feature_selection.variance_threshold.SKlearn",
+    "d3m.primitives.feature_extraction.kernel_pca.SKlearn",
+    # Note: These primitives return an empty DF when the data doesn't
+    # have enough signal and only has one column:
+    "d3m.primitives.data_preprocessing.quantile_transformer.SKlearn",
+]
+
+# These preprocessors never throw errors due to degenerate data
+# (i.e. data with no signal). 
+bulletproof_preprocessors = [
+    "d3m.primitives.data_preprocessing.standard_scaler.SKlearn",
+    "d3m.primitives.feature_extraction.pca.SKlearn",
     "d3m.primitives.data_preprocessing.min_max_scaler.SKlearn",
     "d3m.primitives.data_preprocessing.nystroem.SKlearn",
-    "d3m.primitives.data_preprocessing.quantile_transformer.SKlearn",
     "d3m.primitives.data_preprocessing.random_trees_embedding.SKlearn",
-    "d3m.primitives.feature_selection.variance_threshold.SKlearn"
 ]
+
+# All useable preprocessors. Use these in production.
+preprocessors = temperamental_preprocessors + bulletproof_preprocessors
 
 not_working_preprocessors = [
     # These preprocessors have not been fixed yet by JPL: TODO: check this, it's old

--- a/experimenter/constants.py
+++ b/experimenter/constants.py
@@ -3,11 +3,13 @@ preprocessors = [
     "d3m.primitives.feature_selection.generic_univariate_select.SKlearn",
     "d3m.primitives.feature_extraction.kernel_pca.SKlearn",
     "d3m.primitives.feature_extraction.pca.SKlearn",
-    "d3m.primitives.data_transformation.fast_ica.SKlearn",
     "d3m.primitives.feature_selection.select_fwe.SKlearn",
     "d3m.primitives.feature_selection.select_percentile.SKlearn",
     "d3m.primitives.data_preprocessing.min_max_scaler.SKlearn",
     "d3m.primitives.data_preprocessing.nystroem.SKlearn",
+    "d3m.primitives.data_preprocessing.quantile_transformer.SKlearn",
+    "d3m.primitives.data_preprocessing.random_trees_embedding.SKlearn",
+    "d3m.primitives.feature_selection.variance_threshold.SKlearn"
 ]
 
 not_working_preprocessors = [
@@ -20,8 +22,7 @@ not_working_preprocessors = [
     # "d3m.primitives.data_preprocessing.polynomial_features.SKlearn",
     # "d3m.primitives.data_transformation.ordinal_encoder.SKlearn",
     # "d3m.primitives.data_transformation.one_hot_encoder.SKlearn",
-    # "d3m.primitives.data_preprocessing.rfe.SKlearn",  # Crashes the terminal
-
+    # "d3m.primitives.data_transformation.fast_ica.SKlearn", # Can't handle a column with all the same values
 ]
 
 models = {
@@ -32,13 +33,17 @@ models = {
         "d3m.primitives.classification.decision_tree.SKlearn",
         "d3m.primitives.classification.gaussian_naive_bayes.SKlearn",
         "d3m.primitives.classification.k_neighbors.SKlearn",
-        "d3m.primitives.classification.linear_discriminant_analysis.SKlearn",
         "d3m.primitives.classification.logistic_regression.SKlearn",
         "d3m.primitives.classification.linear_svc.SKlearn",
         "d3m.primitives.classification.sgd.SKlearn",
         "d3m.primitives.classification.svc.SKlearn",
         "d3m.primitives.classification.extra_trees.SKlearn", # randomly splits - different than random forest
         "d3m.primitives.classification.passive_aggressive.SKlearn", # an mlp with regularization
+        "d3m.primitives.classification.ada_boost.SKlearn",
+        "d3m.primitives.classification.mlp.SKlearn",
+        "d3m.primitives.classification.nearest_centroid.SKlearn",
+        # "d3m.primitives.classification.multinomial_naive_bayes.SKlearn", # Can't handle negative data
+        # "d3m.primitives.classification.linear_discriminant_analysis.SKlearn", # Fails when the values of X are all the same.
         # "d3m.primitives.classification.bagging.SKlearn", # only uses decision trees, which is redudant
     ],
     'regression': [

--- a/experimenter/experiments/ensemble.py
+++ b/experimenter/experiments/ensemble.py
@@ -22,10 +22,12 @@ class EnsembleArchitectureExperimenter(Experiment):
 
     def generate_pipelines(
         self,
+        *,
         preprocessors: list,
         models: Dict[str,str],
         n_classifiers: int,
-        n_preprocessors: int
+        n_preprocessors: int,
+        **unused_args
     ) -> Dict[str, List[Pipeline]]:
         """
         This function does differing preprocessors and same model, or differing models and same preprocessor

--- a/experimenter/experiments/experiment.py
+++ b/experimenter/experiments/experiment.py
@@ -11,12 +11,17 @@ class Experiment(ABC):
     """
 
     @abstractmethod
-    def generate_pipelines(self) -> Dict[str, List[Pipeline]]:
+    def generate_pipelines(self, **args) -> Dict[str, List[Pipeline]]:
         """
         Should return a mapping of problem type to a list of
         pipelines outfitted for that problem type e.g.
         `{"classification": [Pipeline()], "regression": [Pipeline()]}`.
-        Subclasses can define whatever input parameters they want.
+
+        Subclasses inheriting this method should always gather up the
+        remaining keyword arguments, since all CLI arguments are passed
+        to this function when called by the `Experimenter` class. This
+        function can choose which CLI arguments to subscribe to by
+        adding them as keyword arguments to the function signature.
         """
         pass
     

--- a/experimenter/experiments/metafeatures.py
+++ b/experimenter/experiments/metafeatures.py
@@ -14,7 +14,7 @@ class MetafeatureExperimenter(Experiment):
     a dataset.
     """
 
-    def generate_pipelines(self) -> Dict[str, List[Pipeline]]:
+    def generate_pipelines(self, **unused_args) -> Dict[str, List[Pipeline]]:
         pipeline_description = self.generate_pipeline()
         return {"classification": [pipeline_description], "regression": [pipeline_description]}
     

--- a/experimenter/experiments/random.py
+++ b/experimenter/experiments/random.py
@@ -1,22 +1,346 @@
-from typing import Dict, List
+from typing import Dict, List, Tuple, Set, Optional
+from collections import defaultdict
+from copy import copy
+import random
+import itertools
 
-from d3m.metadata.pipeline import Pipeline
+from d3m.metadata.pipeline import Pipeline, PrimitiveStep
+from d3m.metadata.base import Context, ArgumentType
+from d3m import index as d3m_index
 
 from experimenter.experiments.experiment import Experiment
+from experimenter.pipeline_builder import (
+    EZPipeline, PipelineArchDesc, add_initial_steps, get_required_args, add_pipeline_step, add_predictions_constructor, map_pipeline_step_arguments
+)
+from experimenter.utils import multiply
+from experimenter.constants import primitives_needing_gt_one_column
 
 class RandomArchitectureExperimenter(Experiment):
     """
     Generates diverse pipelines of random architectures.
     """
 
-    def generate_pipelines(self) -> Dict[str, List[Pipeline]]:
+    # Public methods
+
+    def generate_pipelines(
+        self,
+        *,
+        preprocessors: List[str],
+        models: Dict[str,str],
+        n_structures: int,
+        n_pipelines_per_structure: int,
+        depth_sample_range: Tuple[int, int],
+        max_width_sample_range: Tuple[int, int],
+        max_inputs_sample_range: Tuple[int, int],
+        max_complexity_factor: int,
+        **unused_args
+
+    ) -> Dict[str, List[Pipeline]]:
         """
-        TODO: Implement.
+        :param preprocessors: A list of preprocessor primitive python paths to
+            use to generate pipelines with.
+        :param models: A dict containing two keys of `classification` and `regression`
+            each with a list of model primitive python paths.
+        :param n_structures: The number of pipeline structures to sample from the
+            random architecture space.
+        :param n_pipelines_per_structure: The number of pipelines to make for each
+            structure. Each pipeline's primitives will be sampled from
+            `preprocessors` and `models`, so the probability of pipelines using the
+            same sequence of primitives is low.
+        :param depth_sample_range: An integer range to sample from to determine the
+            depth of each pipeline structure.
+        :param max_width_sample_range: An integer range to sample from to determine
+            a 'layer width' sample range for each pipeline structure.
+        :param max_inputs_sample_range: An integer range to sample from to determine
+            a 'number of inputs' sample range for each pipeline structure.
+        :param max_complexity_factor: For each structure sampled, the structure's
+            `depth * max_width * max_num_inputs` will not exceed this value.
+        :return: A dict containing two keys of `classification` and `regression` each a
+            list of pipeline objects. Each list will have `n_structures *
+            n_pipelines_per_structure` total pipelines.
         """
-        raise NotImplementedError
+        generated_pipelines: Dict[str, List[Pipeline]] = defaultdict(list)
+        for type_name, model_list in models.items():
+
+            # Sample the structures
+            structures = []
+            for _ in range(n_structures):
+                depth, max_width, max_num_inputs = self._sample_parameters(
+                    [depth_sample_range, max_width_sample_range, max_inputs_sample_range],
+                    max_complexity_factor
+                )
+                structures.append(self._sample_structure(depth, max_width, max_num_inputs))
+
+            # Sample pipelines from each structure
+            for structure, num_inputs_by_step in structures:
+                for _ in range(n_pipelines_per_structure):
+                    generated_pipelines[type_name].append(
+                        self._sample_pipeline(structure, preprocessors, model_list, num_inputs_by_step)
+                    )
+        
+        return generated_pipelines
     
-    def generate_pipeline(self) -> Pipeline:
+    def generate_pipeline(
+        self,
+        preprocessors: List[str],
+        model_list: List[str],
+        depth: int,
+        max_width: int,
+        max_num_inputs: int
+    ) -> EZPipeline:
         """
-        TODO: Implement.
+        Similar to `self.generate_pipelines`, but generates a single pipeline from
+        a single random structure.Also, doesn't take sample ranges, but a `depth`,
+        `max_width`, and `max_num_inputs` directly.
+
+        :param preprocessors: A list of preprocessor primitive python paths.
+        :param model_list: A list of ML model (e.g. random forest, knn, etc.)
+            primitive python paths.
+        :param depth: The depth the pipeline structure will have i.e. the number
+            of layers.
+        :param max_width: The maximum width for each layer in the structure.
+        :param max_num_inputs: The maximum number of inputs each primitive in the
+            structure will have.
         """
-        raise NotImplementedError
+        structure, num_inputs_by_step = self._sample_structure(depth, max_width, max_num_inputs)
+        pipeline = self._sample_pipeline(structure, preprocessors, model_list, num_inputs_by_step)
+        return pipeline
+
+    
+    # Private methods
+
+    def _sample_structure(self, depth: int, max_width: int, max_num_inputs: int) -> Tuple[EZPipeline, Dict[int, int]]:
+        """
+        :param depth: The depth the pipeline structure will have i.e. the number
+            of layers.
+        :param max_width: The maximum width for each layer in the structure.
+        :param max_num_inputs: The maximum number of inputs each primitive in the
+            structure will have.
+        """
+        # A mapping of data reference pairs to the data reference of their
+        # concatenation.
+        concat_cache: Dict[frozenset, str] = {}
+
+        architecture = PipelineArchDesc(
+            "random",
+            { "depth": depth, "max_width": max_width, "max_num_inputs": max_num_inputs }
+        )
+        structure = EZPipeline(arch_desc=architecture, context=Context.TESTING)
+        add_initial_steps(structure)
+        # The running collection of all step data references that can
+        # be used as inputs for subsequent primitives in the pipeline. 
+        output_collection: Set[str] = { structure.data_ref_of('attrs') }
+        terminal_node_data_refs: Set[str] = set()
+        # Keeps track of the number of inputs each step is using
+        num_inputs_by_step: Dict[int, int] = defaultdict(int)
+
+        # Pipeline Build Phase
+
+        for _ in range(depth):
+            layer_width = random.randint(1, max_width)
+            layer_outputs: Set[str] = set()
+            for _ in range(layer_width):
+                
+                num_inputs = random.randint(1, max_num_inputs)
+                # There are only `len(output_collection)` possible inputs available.
+                num_inputs = min(len(output_collection), num_inputs)
+                input_refs: Set[str] = set(random.sample(output_collection, num_inputs))
+
+                # Since the steps identified by `input_refs` are now being used
+                # as inputs, we know they're not terminal nodes anymore.
+                terminal_node_data_refs -= input_refs
+
+                concat_result_ref = self._concatenate_inputs(structure, input_refs, concat_cache)
+                # Add the do nothing primitive as a placeholder. `self._sample_pipeline` will fill
+                # in the primitives later.
+                add_pipeline_step(
+                    structure,
+                    'd3m.primitives.data_preprocessing.do_nothing.DSBOX',
+                    concat_result_ref
+                )
+                num_inputs_by_step[structure.curr_step_i] = num_inputs
+
+                terminal_node_data_refs.add(structure.curr_step_data_ref)
+                layer_outputs.add(structure.curr_step_data_ref)
+
+            output_collection.update(layer_outputs)
+        
+        # Cleanup Phase
+
+        # Route the output of all terminal nodes to a final primitive
+        final_concat_ref = self._concatenate_inputs(structure, terminal_node_data_refs, concat_cache)
+        add_pipeline_step(
+            structure,
+            'd3m.primitives.data_preprocessing.do_nothing.DSBOX',
+            final_concat_ref
+        )
+        structure.set_step_i_of('final_model')
+
+        add_predictions_constructor(structure)
+        # Adding output step to the pipeline
+        structure.add_output(name='Output', data_reference=structure.curr_step_data_ref)
+        return structure, num_inputs_by_step
+    
+    def _sample_pipeline(
+        self,
+        structure: EZPipeline,
+        preprocessors: List[str],
+        model_list: List[str],
+        num_inputs_by_step: Dict[int, int]
+    ) -> EZPipeline:
+        """
+        :param structure: An `EZPipeline`. Every step in `structure` that uses
+            a do nothing primitive will be replaced with a primitive sampled from
+            `preprocessors` and `model_list`.
+        :param preprocessors: A list of preprocessor primitive python paths.
+        :param model_list: A list of ML model (e.g. random forest, knn, etc.)
+            primitive python paths.
+        :param num_inputs_by_step: A map of `structure`'s step indices to the
+            number of inputs each of those steps have.
+        """
+        all_primitives = set(preprocessors + model_list)
+        primitives_that_can_handle_one_input_column = all_primitives - primitives_needing_gt_one_column
+
+        # Replace all placeholder primitives with randomly sampled preprocessors
+        # and models
+        for step_i, old_step in enumerate(structure.steps):
+            if old_step.primitive.metadata.query()["python_path"] == 'd3m.primitives.data_preprocessing.do_nothing.DSBOX':
+
+                # This is a placeholder primitive that's to be filled in by a new step.
+                if num_inputs_by_step[step_i] == 1:
+                    # There's a chance this primitive will only be taking one input column
+                    new_primitive_python_path, = random.sample(primitives_that_can_handle_one_input_column, 1)
+                else:
+                    new_primitive_python_path, = random.sample(all_primitives, 1)
+
+                self._replace_step_at_i(structure, step_i, new_primitive_python_path)
+        
+        # Finally, make sure the last primitive before the construct predictions step
+        # is a model.
+        final_placeholder_step_i = structure.step_i_of('final_model')
+        new_model_python_path, = random.sample(model_list, 1)
+        self._replace_step_at_i(structure, final_placeholder_step_i, new_model_python_path)
+        structure.steps[final_placeholder_step_i].hyperparams['return_result'] = {
+            'type': ArgumentType.VALUE,
+            'data': 'new',
+        }
+
+        return structure
+    
+    def _replace_step_at_i(
+        self,
+        pipeline: EZPipeline,
+        step_i: int,
+        new_step_python_path: str
+    ) -> None:
+        new_primitive = d3m_index.get_primitive(new_step_python_path)
+        new_step = PrimitiveStep(primitive=new_primitive)
+        old_step_inputs_data_ref = pipeline.steps[step_i].arguments['inputs']['data']
+        # Fill in the new step's arguments
+        map_pipeline_step_arguments(
+            pipeline,
+            new_step,
+            get_required_args(new_primitive),
+            # Preserve the inputs the old step was using.
+            custom_data_ref=old_step_inputs_data_ref
+        )
+        pipeline.replace_step(step_i, new_step)
+
+    def _sample_parameters(self, ranges: List[Tuple[int, int]], max_sample_prod: int) -> Tuple[int, ...]:
+        """
+        :param ranges: A list of integer ranges. Each will be sampled from uniformly.
+        :param max_sample_prod: A maximum threshold for the product of all
+            sampled values. Sampling will keep occuring until samples falling within
+            this threshold are produced.
+        :return: A tuple contained a sample for each of the sample ranges in `ranges`.
+        """
+        samples = tuple(random.randint(*rng) for rng in ranges)
+        while multiply(samples) > max_sample_prod:
+            samples = tuple(random.randint(*rng) for rng in ranges)
+        return samples
+    
+    def _find_match_in_cache(
+        self, data_refs: Set[str],
+        concat_cache: Dict[frozenset, str]
+    ) -> Optional[frozenset]:
+        """
+        Uses all unordered combinations from `data_refs` (n choose k where k goes
+        from n to 2) to find a match in `cache`, that is to say, a set of data refs in
+        `data_refs` who have already been concatenated.
+
+        :param data_refs: The set of data_refs to search in the cache for.
+        :param concat_cache: The cache that maps data ref pairs to the data ref of
+            their concatenated output.
+        :return: If a match is found, the matching data ref pair is returned, else
+            None is returned. 
+        """
+        for k in range(len(concat_cache), 1, -1):
+            # Use all unordered combinations from `data_refs`
+            # (n choose k where k goes from n to 2)
+            for subset in itertools.combinations(data_refs, k):
+                subset = frozenset(subset)
+                if subset in concat_cache:
+                    return subset
+        return None
+    
+    def _concatenate_inputs(
+        self,
+        pipeline: EZPipeline,
+        data_refs_to_concat: Set[str],
+        concat_cache: Dict[frozenset, str]
+    ) -> str:
+        """
+        Adds concatenation steps to `pipeline` that join the outputs of every data
+        reference found in `data_refs_to_concat` until they are all a single data frame.
+
+        :param pipeline: The pipeline the concatenation steps will be added to.
+        :param data_refs_to_concat: The data references to the steps whose outputs are to be
+            concatentated together.
+        :param concat_cache: A cache holding data about previously concatenated outputs.
+            If two steps in `data_refs_to_concat` have already been concatenated in another step on
+            `pipeline`, then that concatenation step will be referenced during this
+            concatenation, instead of creating a new duplicate concatenation step. Reduces
+            the runtime and memory footprint of the pipeline.
+        """
+        if len(data_refs_to_concat) == 1:
+            # No concatenation necessary
+            output_data_ref, = data_refs_to_concat
+            return output_data_ref
+        
+        data_refs = copy(data_refs_to_concat)
+
+        while len(data_refs) > 1:
+            # first look in `concat_cache` for an already existing
+            # concatenation we can use.
+            cache_match = self._find_match_in_cache(data_refs, concat_cache)
+            
+            if cache_match is None:
+                # Manually concatenate a pair of data refs, then add them to the cache.
+                data_ref_pair = sorted(data_refs)[:2]
+                concat_step = self._build_concatenate_step(*data_ref_pair)
+                pipeline.add_step(concat_step)
+                concat_data_ref = pipeline.curr_step_data_ref
+
+                # Save the link between the data ref pair and their concatenation's
+                # output to the `concat_cache`.
+                data_ref_pair = frozenset(data_ref_pair)
+                concat_cache[data_ref_pair] = concat_data_ref
+                # Now we have a match in the cache.
+                cache_match = data_ref_pair
+
+            # Now that we've concatenated `data_ref_pair`, we don't
+            # need it in `data_refs` anymore.
+            data_refs -= cache_match
+            data_refs.add(concat_cache[cache_match])
+        
+        output_data_ref, = data_refs
+        return output_data_ref
+    
+    def _build_concatenate_step(self, left_data_ref: str, right_data_ref: str) -> PrimitiveStep:
+        concat_step = PrimitiveStep(
+            primitive=d3m_index.get_primitive('d3m.primitives.data_transformation.horizontal_concat.DataFrameConcat')
+        )
+        concat_step.add_argument(name='left', argument_type=ArgumentType.CONTAINER, data_reference=left_data_ref)
+        concat_step.add_argument(name='right', argument_type=ArgumentType.CONTAINER, data_reference=right_data_ref)
+        concat_step.add_output('produce')
+        return concat_step

--- a/experimenter/experiments/stacked.py
+++ b/experimenter/experiments/stacked.py
@@ -9,7 +9,7 @@ class StackedArchitectureExperimenter(Experiment):
     Generates diverse pipelines of stacked architectures.
     """
 
-    def generate_pipelines(self) -> Dict[str, List[Pipeline]]:
+    def generate_pipelines(self, **unused_args) -> Dict[str, List[Pipeline]]:
         """
         TODO: Implement.
         """

--- a/experimenter/experiments/straight.py
+++ b/experimenter/experiments/straight.py
@@ -17,8 +17,10 @@ class StraightArchitectureExperimenter(Experiment):
 
     def generate_pipelines(
         self,
+        *
         preprocessors: List[str],
-        models: Dict[str,str]
+        models: Dict[str,str],
+        **unused_args
     ) -> Dict[str, List[Pipeline]]:
         """
         A high level function to create numerous pipelines for a list of preprocessor and model

--- a/experimenter/pipeline_builder.py
+++ b/experimenter/pipeline_builder.py
@@ -198,8 +198,8 @@ def map_pipeline_step_arguments(
 
         step.add_argument(name=arg, argument_type=ArgumentType.CONTAINER,
                             data_reference=data_ref)
-    step.add_hyperparameter(name='use_semantic_types', argument_type=ArgumentType.VALUE, data=True)
-    step.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data="replace")
+    step.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data="new")
+
     # handle any extra hyperparams needed
     step_python_path = step.primitive.metadata.query()["python_path"]
     if step_python_path in EXTRA_HYPEREPARAMETERS:

--- a/experimenter/pipeline_builder.py
+++ b/experimenter/pipeline_builder.py
@@ -172,7 +172,8 @@ def map_pipeline_step_arguments(
     pl: EZPipeline,
     step: PrimitiveStep,
     required_args: list,
-    use_current_step_data_ref: bool = False
+    use_current_step_data_ref: bool = False,
+    custom_data_ref: str = None
 ) -> None:
     """
     Helper used to add arguments to a PrimitiveStep.
@@ -184,6 +185,8 @@ def map_pipeline_step_arguments(
     :param use_current_step_data_ref: For arguments other than 'outputs', this
         boolean indicates whether to use the data reference of the current step
         rather than 'attrs'.
+    :param custom_data_ref: If provided, this will be used as the data reference
+        for all arguments other than 'outputs'.
 
     :rtype: None
     """
@@ -191,7 +194,9 @@ def map_pipeline_step_arguments(
         if arg == "outputs":
             data_ref = pl.data_ref_of('target')
         else:
-            if use_current_step_data_ref:
+            if custom_data_ref:
+                data_ref = custom_data_ref
+            elif use_current_step_data_ref:
                 data_ref = pl.curr_step_data_ref
             else:
                 data_ref = pl.data_ref_of('attrs')

--- a/experimenter/pipeline_builder.py
+++ b/experimenter/pipeline_builder.py
@@ -201,9 +201,11 @@ def map_pipeline_step_arguments(
     step.add_hyperparameter(name='use_semantic_types', argument_type=ArgumentType.VALUE, data=True)
     step.add_hyperparameter(name='return_result', argument_type=ArgumentType.VALUE, data="replace")
     # handle any extra hyperparams needed
-    if step in EXTRA_HYPEREPARAMETERS:
-        params = EXTRA_HYPEREPARAMETERS[step]
-        step.add_hyperparameter(name=params["name"], argument_type=params["type"], data=params["data"])
+    step_python_path = step.primitive.metadata.query()["python_path"]
+    if step_python_path in EXTRA_HYPEREPARAMETERS:
+        params = EXTRA_HYPEREPARAMETERS[step_python_path]
+        for param in params:
+            step.add_hyperparameter(name=param["name"], argument_type=param["type"], data=param["data"])
     step.add_output('produce')
 
 

--- a/experimenter/utils.py
+++ b/experimenter/utils.py
@@ -1,6 +1,8 @@
 import inspect
 import json
 import os
+import functools
+from typing import Callable, Any
 
 from d3m.metadata import problem as problem_module
 
@@ -68,3 +70,8 @@ def get_default_args(f):
         k: v.default for k, v in inspect.signature(f).parameters.items()
         # if v.default is not inspect.Parameter.empty
     }
+
+
+def multiply(l: list) -> float:
+    """Multiplies all the elements in a list together"""
+    return functools.reduce((lambda x, y: x * y), l)

--- a/experimenter_driver.py
+++ b/experimenter_driver.py
@@ -1,3 +1,4 @@
+from typing import List
 import warnings, argparse, logging
 import logging.config as log_config
 from d3m.metadata.pipeline import Pipeline
@@ -231,21 +232,25 @@ def main(**cli_args):
         elif run_type == "distribute":
             experimenter_driver = ExperimenterDriver(datasets_dir, volumes_dir, **cli_args)
             experimenter_driver.run(**cli_args)
-                return
+            return
 
         experimenter_driver = ExperimenterDriver(datasets_dir, volumes_dir, **cli_args)
         experimenter_driver.run(**cli_args)
 
 
-if __name__ == "__main__":
+def get_cli_args(raw_args: List[str] = None):
+    """
+    If `raw_args` is `None`, `sys.argv` will be used. `raw_args`
+    can be supplied when testing.
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--run-type",
         '-r',
         help=(
             "How to run the driver. 'all' generates and executes, 'execute' "
-                                                 "only executes pipelines from the database, 'pipeline_path' "
-                                                 "executes pipelines from a specific folder and 'generate' only "
+            "only executes pipelines from the database, 'pipeline_path' "
+            "executes pipelines from a specific folder and 'generate' only "
             "creates pipelines and stores them in the database"
         ),
         choices=["all", "execute", "generate", "pipeline_path", "distribute"],
@@ -280,14 +285,14 @@ if __name__ == "__main__":
         "--n-preprocessors",
         "-np",
         type=int,
-        help="how many preprocessors to use for generation",
+        help="how many preprocessors to use for the ensemble experiment",
         default=3
     )
     parser.add_argument(
         "--n-classifiers",
         "-nc",
         type=int,
-        help="how many classifiers to use for generation",
+        help="how many classifiers to use for the ensemble experiment",
         default=3
     )
     parser.add_argument(
@@ -296,7 +301,71 @@ if __name__ == "__main__":
         help="seed to use for random generation",
         default=0
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--n-structures",
+        "-ns",
+        type=int,
+        help="how many pipeline structures to sample for the random experiment"
+    )
+    parser.add_argument(
+        "--n-pipelines-per-structure",
+        "-nps",
+        type=int,
+        help="how many pipelines to sample from each structure for the random experiment",
+        default=8
+    )
+    parser.add_argument(
+        "--depth-sample-range",
+        "-dsr",
+        nargs=2,
+        type=int,
+        help=(
+            "the range to sample pipeline depths from for the random experiment e.g. "
+            "`-dps 2 10` will sample in the integer range [2,10]"
+        ),
+        default=[1,8],
+        metavar=('lower', 'upper')
+    )
+    parser.add_argument(
+        "--max-width-sample-range",
+        "-mwsr",
+        nargs=2,
+        type=int,
+        help=(
+            "the range to sample pipeline max widths from for the random experiment e.g. "
+            "`-mwsr 2 10` will sample in the integer range [2,10]"
+        ),
+        default=[1,8],
+        metavar=('lower', 'upper')
+    )
+    parser.add_argument(
+        "--max-inputs-sample-range",
+        "-misr",
+        nargs=2,
+        type=int,
+        help=(
+            "the range to sample the number of inputs for each primitive in a pipeline from "
+            "for the random experiment e.g. `-misr 2 10` will sample in the integer range [2,10]"
+        ),
+        default=[1,4],
+        metavar=('lower', 'upper')
+    )
+    parser.add_argument(
+        "--max-complexity-factor",
+        "-mcf",
+        type=int,
+        help=(
+            "pipeline structures produced by the random experiment will each honor this constraint: "
+            "`depth * max_width * max_inputs < max_complexity_factor`"
+        ),
+        default=24
+    )
+    args = parser.parse_args(raw_args)
+    return args
+
+
+if __name__ == "__main__":
+    args = get_cli_args()
     if args.verbose:
         logging.basicConfig(level=logging.INFO)
     else:

--- a/experimenter_driver.py
+++ b/experimenter_driver.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 from experimenter.experimenter import Experimenter
 import os, json, pdb, traceback, sys
 from experimenter.database_communication import PipelineDB
-from experimenter.experimenter import _pretty_print_json
+from experimenter.experimenter import pretty_print_json
 import warnings, argparse
 import redis
 from rq import Queue
@@ -27,27 +27,35 @@ class ExperimenterDriver:
     This is the main class for running the experimenter.  Command line options for running this file are found at the bottom of the file.
     """
 
-    def __init__(self, datasets_dir: str, volumes_dir: str, run_type: str ="all",
-                 stored_pipeline_loc=None, distributed=False
-                 fit_only=False, args: dict):
+    def __init__(
+        self,
+        datasets_dir: str,
+        volumes_dir: str,
+        *,
+        run_type: str ="all",
+        pipeline_folder=None,
+        distribute=False,
+        run_custom_fit=False,
+        **unused_args
+    ):
         self.datasets_dir = datasets_dir
         self.volumes_dir = volumes_dir
         self.run_type = run_type
-        self.distributed = distributed
-        self.fit_only = fit_only
+        self.distribute = distribute
+        self.fit_only = run_custom_fit
 
         if run_type == "pipeline_path":
-            if stored_pipeline_loc is None:
+            if pipeline_folder is None:
                 self.pipeline_location = "created_pipelines/"
             else:
-                self.pipeline_location = stored_pipeline_loc
+                self.pipeline_location = pipeline_folder
         else:
             self.pipeline_location = None
 
         # connect to database
         self.mongo_db = PipelineDB()
 
-        if distributed:
+        if distribute:
             logger.info("Connecting to Redis")
             try:
                 conn = redis.StrictRedis(
@@ -78,8 +86,8 @@ class ExperimenterDriver:
         :param problem: the problem that the pipeline failed on
         :param error: the reason for failure
         """
-        logger.info("\nFailed to run pipeline:\n" + self.get_list_vertically(
-            self.primitive_list_from_pipeline_object(pipeline)) + "\n")
+        logger.info("\nFailed to run pipeline:\n" + get_list_vertically(
+            primitive_list_from_pipeline_object(pipeline)) + "\n")
         logger.info("On the problem:\n{}\n".format(problem))
         logger.info("ERROR: " + str(error))
         traceback.print_exc()
@@ -104,31 +112,35 @@ class ExperimenterDriver:
         return pipeline_list
 
 
-    def run(self):
+    def run(self, **cli_args):
         if self.run_type == "pipeline_path":
             logger.info("Executing pipelines found in {}".format(self.pipeline_location))
             if self.pipeline_location is None:
                 raise NotADirectoryError
             else:
                 pipes = self.get_pipelines_from_path(self.pipeline_location)
-                experimenter = Experimenter(self.datasets_dir, self.volumes_dir,
-                                            generate_pipelines=False, generate_problems=True,
-                                            pipeline_gen_type=args.pipeline_gen_type,
-                                            n_classifiers=args.n_classifiers,
-                                            n_preprocessors=args.n_preprocessors)
+                experimenter = Experimenter(
+                    self.datasets_dir,
+                    self.volumes_dir,
+                    generate_pipelines=False,
+                    generate_problems=True,
+                    **cli_args
+                )
                 problems = experimenter.problems
         # run type is pipelines from mongodb or "all"
         else:
             # generating the pipelines has already been taken care of
-            experimenter = Experimenter(self.datasets_dir, self.volumes_dir,
-                                        generate_problems=True, generate_pipelines=False
-                                        pipeline_gen_type=args.pipeline_gen_type,
-                                        n_classifiers=args.n_classifiers,
-                                        n_preprocessors=args.n_preprocessors)
+            experimenter = Experimenter(
+                self.datasets_dir,
+                self.volumes_dir,
+                generate_problems=True,
+                generate_pipelines=False,
+                **cli_args)
             problems: dict = experimenter.problems
             if self.fit_only:
                 logger.info("Using only the fit pipeline")
-                pipes, num_pipes = experimenter.generate_metafeatures_pipeline()
+                pipes = experimenter.experiments["metafeatures"].generate_pipelines()
+                num_pipes = [len(pipe_list) for pipe_list in pipes.values()]
             else:
                 logger.info("\n Gathering pipelines from database...")
                 pipes, num_pipes = self.mongo_db.get_all_pipelines()
@@ -149,12 +161,12 @@ class ExperimenterDriver:
                                                                  collection_name="pipeline_runs",
                                                                  skip_pipeline=self.fit_only):
                             logger.info("\n SKIPPING. Pipeline already run.")
-                            self.print_pipeline_and_problem(pipe, problem)
+                            print_pipeline_and_problem(pipe, problem)
                             continue
 
                         try:
                             # if we are trying to distribute, add to the RQ
-                            if self.distributed:
+                            if self.distribute:
                                 if not self.fit_only:
                                     async_results = self.queue.enqueue(execute_pipeline_on_problem, pipe, problem,
                                                                        self.datasets_dir, self.volumes_dir, timeout=60*12)
@@ -170,7 +182,7 @@ class ExperimenterDriver:
                             # pipeline didn't work.  Try the next one
                             raise e
 
-        _pretty_print_json(experimenter.incorrect_problem_types)  # For debugging purposes
+        pretty_print_json(experimenter.incorrect_problem_types)  # For debugging purposes
 
 
 
@@ -199,67 +211,94 @@ python3 experimenter_driver.py -r generate -f default (creates pipelines in defa
 python3 experimenter_driver.py -r generate -f other_folder/ (creates pipelines and stores them in "other_folder/")
 
 """
-def main(run_type: str, pipeline_folder: str, only_run_fit: bool, args: dict):
+def main(**cli_args):
 
     datasets_dir = '/datasets'
     volumes_dir = '/volumes'
+    run_type = cli_args["run_type"]
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore")
         if run_type == "all":
             # Generate all possible problems and get pipelines - use default directory, classifiers, and preprocessors
-            experimenter = Experimenter(datasets_dir, volumes_dir, generate_pipelines=True,
-                                        generate_problems=True, pipeline_gen_type=args.pipeline_gen_type, n_classifiers=args.n_classifiers,
-                                        n_preprocessors=args.n_preprocessors)
+            Experimenter(datasets_dir, volumes_dir, generate_pipelines=True, generate_problems=True, **cli_args)
 
         elif run_type == "generate":
             logger.info("Only generating pipelines...")
-            experimenter = Experimenter(datasets_dir, volumes_dir, generate_pipelines=True,
-                                        location=pipeline_folder, pipeline_gen_type=args.pipeline_gen_type, n_classifiers=args.n_classifiers,
-                                        n_preprocessors=args.n_preprocessors)
+            Experimenter(datasets_dir, volumes_dir, generate_pipelines=True, **cli_args)
             return
 
         elif run_type == "distribute":
-            if not only_run_fit:
-                experimenter_driver = ExperimenterDriver(datasets_dir, volumes_dir,
-                                                         run_type=run_type, stored_pipeline_loc=pipeline_folder,
-                                                         distributed=True)
-                experimenter_driver.run()
-
-                return
-            else:
-                experimenter_driver = ExperimenterDriver(datasets_dir, volumes_dir,
-                                                         run_type=run_type, stored_pipeline_loc=pipeline_folder,
-                                                         distributed=True,
-                                                         fit_only=only_run_fit)
-                experimenter_driver.run()
-
+            experimenter_driver = ExperimenterDriver(datasets_dir, volumes_dir, **cli_args)
+            experimenter_driver.run(**cli_args)
                 return
 
-        experimenter_driver = ExperimenterDriver(datasets_dir, volumes_dir,
-                                                 run_type=run_type, stored_pipeline_loc=pipeline_folder)
-        experimenter_driver.run()
+        experimenter_driver = ExperimenterDriver(datasets_dir, volumes_dir, **cli_args)
+        experimenter_driver.run(**cli_args)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--run-type", '-r', help="How to run the driver.  'all' generates and executes, 'execute' "
+    parser.add_argument(
+        "--run-type",
+        '-r',
+        help=(
+            "How to run the driver. 'all' generates and executes, 'execute' "
                                                  "only executes pipelines from the database, 'pipeline_path' "
                                                  "executes pipelines from a specific folder and 'generate' only "
-                                                 "creates pipelines and stores them in the database",
-                        choices=["all", "execute", "generate", "pipeline_path", "distribute"], default="all")
-    parser.add_argument("--pipeline-folder", '-f', help="The path of the folder containing/to receive the pipelines")
-    parser.add_argument("--run-custom-fit", '-c', help="Whether or not to run only fit and use given pipelines",
-                        action='store_true')
-    parser.add_argument("--pipeline-gen-type", '-p', help="what type of pipelines to generate: ensembles, straight, metafeature, or random",
-                        choices=["ensemble", "straight", "metafeatures", "random", "stacked"], default="straight")
-    parser.add_argument("--verbose", "-v", action="store_true", help="Whether to print for debugging or not", default=False)
-    parser.add_argument("--n_preprocessors", "-np", type=int, help="how many preprocessors to use for generation", default=3)
-    parser.add_argument("--n_classifiers", "-nc", type=int, help="how many classifiers to use for generation", default=3)
-    parser.add_argument("--seed", type=int, help="seed to use for random generation", default=0) 
+            "creates pipelines and stores them in the database"
+        ),
+        choices=["all", "execute", "generate", "pipeline_path", "distribute"],
+        default="all"
+    )
+    parser.add_argument(
+        "--pipeline-folder",
+        '-f',
+        help="The path of the folder containing/to receive the pipelines"
+    )
+    parser.add_argument(
+        "--run-custom-fit",
+        '-c',
+        help="Whether or not to run only fit and use given pipelines",
+        action='store_true'
+    )
+    parser.add_argument(
+        "--pipeline-gen-type",
+        '-p',
+        help="what type of pipelines to generate: ensembles, straight, metafeature, or random",
+        choices=["ensemble", "straight", "metafeatures", "random", "stacked"],
+        default="straight"
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Whether to print for debugging or not",
+        default=False
+    )
+    parser.add_argument(
+        "--n-preprocessors",
+        "-np",
+        type=int,
+        help="how many preprocessors to use for generation",
+        default=3
+    )
+    parser.add_argument(
+        "--n-classifiers",
+        "-nc",
+        type=int,
+        help="how many classifiers to use for generation",
+        default=3
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        help="seed to use for random generation",
+        default=0
+    )
     args = parser.parse_args()
     if args.verbose:
         logging.basicConfig(level=logging.INFO)
     else:
         logging.basicConfig(level=logging.CRITICAL)
-    main(args.run_type, args.pipeline_folder, args.run_custom_fit, args)
+    main(**vars(args))

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,31 @@
+import unittest
+
+from experimenter_driver import get_cli_args
+
+
+class TestCLI(unittest.TestCase):
+
+    def test_ensemble_args(self):
+        """
+        Tests correct parsing of arguments specific to the ensemble experimenter. 
+        """
+        ensemble_args = ['-p', 'ensemble', '-nc', '3', '-np', '1']
+        args = get_cli_args(ensemble_args)
+
+        self.assertEqual(args.pipeline_gen_type, "ensemble")
+        self.assertEqual(args.n_classifiers, 3)
+        self.assertEqual(args.n_preprocessors, 1)
+    
+    def test_random_args(self):
+        """
+        Tests correct parsing of arguments specific to the random experimenter. 
+        """
+        random_args = ['-ns', '100', '-nps', '32', '-dsr', '1', '10', '-mwsr', '1', '5', '-misr', '1', '4', '-mcf', '24']
+        args = get_cli_args(random_args)
+
+        self.assertEqual(args.n_structures, 100)
+        self.assertEqual(args.n_pipelines_per_structure, 32)
+        self.assertEqual(args.depth_sample_range, [1, 10])
+        self.assertEqual(args.max_width_sample_range, [1, 5])
+        self.assertEqual(args.max_inputs_sample_range, [1, 4])
+        self.assertEqual(args.max_complexity_factor, 24)

--- a/test/test_ensembling_pipelines_generation.py
+++ b/test/test_ensembling_pipelines_generation.py
@@ -89,30 +89,6 @@ class TestEnsemblingPipelinesGeneration(unittest.TestCase):
     #     self.assertEqual(num_preprocessors * num_ensembles, preprocessor_count, "The expected number of preprocessors was {} but we got"
     #                                                             "{}".format(num_ensembles * num_preprocessors, preprocessor_count))
 
-    def test_experimenter_can_generate_different_models(self):
-        """
-        Technically this test could fail and still work, but the odds are low
-        """
-        num_models = 5
-        # generate the pipelines
-        generated_pipelines = self.experiment._generate_k_ensembles(k_ensembles=num_models, n_preprocessors=1,
-                                                                   preprocessors=preprocessors,
-                                                                   models=models,
-                                                                   n_generated_pipelines=1, same_model=False,
-                                                                   same_preprocessor_order=True,
-                                                                   problem_type="classification")
-        self.assertEqual(1, len(generated_pipelines["classification"]))
-
-        primitives = primitive_list_from_pipeline_json(generated_pipelines["classification"][0].to_json_structure())
-        model_list = []
-        for primitive in primitives:
-            if primitive in self.models["classification"]:
-                model_list.append(primitive)
-
-        self.assertAlmostEqual(len(set(model_list)), num_models, delta=1, msg="The expected number of unique "
-                                                                         "models was {} but we "
-                                                                         "got {}".format(num_models, model_list))
-
     def test_experimenter_can_generate_same_models(self):
         num_models = 5
         # generate the pipelines

--- a/test/test_pipeline_builder.py
+++ b/test/test_pipeline_builder.py
@@ -39,13 +39,12 @@ class PipelineGenerationTestCase(unittest.TestCase):
         self._add_extract_attrs_step(pipeline)
         pipeline.set_step_i_of('attrs')
         self.assertEqual(pipeline.data_ref_of('attrs'), 'steps.2.produce')
+        self.assertEqual(pipeline.step_i_of('attrs'), 2)
 
         # setting a different ref should not affect an already set ref
         self.assertEqual(pipeline.data_ref_of('raw_df'), 'steps.0.produce')
 
-        # invalid ref names should be invalid
-        with self.assertRaises(Exception):
-            pipeline.set_step_i_of('Jar Jar Binks')
+        # Unset ref names should throw an error, rather than return a value.
         with self.assertRaises(Exception):
             pipeline.data_ref_of('Han Solo')
     

--- a/test/test_random_pipelines.py
+++ b/test/test_random_pipelines.py
@@ -1,0 +1,91 @@
+import unittest
+
+from experimenter.experiments.random import RandomArchitectureExperimenter
+from experimenter.constants import models, preprocessors
+from experimenter.pipeline_builder import EZPipeline
+from experimenter.run_pipeline import RunPipeline
+
+
+class TestRandomPipelines(unittest.TestCase):
+
+    # Test Methods
+
+    def setUp(self):
+        self.datasets_dir = "/datasets"
+        self.volumes_dir = "/volumes"
+        self.problem_path = "/datasets/seed_datasets_current/185_baseball"
+        self.experiment = RandomArchitectureExperimenter()
+        self.preprocessors = preprocessors
+        self.models = models
+    
+    def test_can_generate_pipeline(self) -> None:
+        pipeline = self._generate_random_pipeline()
+        # Make sure the pipeline is valid in D3M's eyes.
+        pipeline.check()
+    
+    def test_can_run_pipeline(self) -> None:
+        pipeline = self._generate_random_pipeline()
+        self._run_experimenter_from_pipeline(pipeline, "wide+deep")
+    
+    def test_can_generate_straight_pipeline(self) -> None:
+        pipeline = self._generate_straight_pipeline()
+        # Make sure the pipeline is valid in D3M's eyes.
+        pipeline.check()
+    
+    def test_can_run_straight_pipeline(self) -> None:
+        pipeline = self._generate_straight_pipeline()
+        self._run_experimenter_from_pipeline(pipeline, "straight")
+    
+    def test_can_generate_wide_pipeline(self) -> None:
+        pipeline = self._generate_wide_pipeline()
+        # Make sure the pipeline is valid in D3M's eyes.
+        pipeline.check()
+    
+    def test_can_run_wide_pipeline(self) -> None:
+        pipeline = self._generate_wide_pipeline()
+        self._run_experimenter_from_pipeline(pipeline, "wide")
+    
+    # Private Methods
+
+    def _generate_random_pipeline(self) -> EZPipeline:
+        pipeline = self.experiment.generate_pipeline(
+            self.preprocessors,
+            self.models['classification'],
+            depth=4,
+            max_width=3,
+            max_num_inputs=2
+        )
+        return pipeline
+
+    def _generate_straight_pipeline(self) -> EZPipeline:
+        pipeline = self.experiment.generate_pipeline(
+            self.preprocessors,
+            self.models['classification'],
+            depth=6,
+            max_width=1,
+            max_num_inputs=2
+        )
+        return pipeline
+
+    def _generate_wide_pipeline(self) -> EZPipeline:
+        pipeline = self.experiment.generate_pipeline(
+            self.preprocessors,
+            self.models['classification'],
+            depth=1,
+            max_width=12,
+            max_num_inputs=3
+        )
+        return pipeline
+
+    def _run_experimenter_from_pipeline(self, pipeline_to_run: EZPipeline, arch_type: str):
+        # run our system
+        run_pipeline = RunPipeline(
+            datasets_dir=self.datasets_dir,
+            volumes_dir=self.volumes_dir,
+            problem_path=self.problem_path
+        )
+        scores_test, _ = run_pipeline.run(pipeline=pipeline_to_run)
+        # the value of score is in the first document in the first index
+        score = scores_test[0]["value"][0]
+        print(f'score for {arch_type} random pipeline: {score}')
+        return score

--- a/test/test_random_pipelines.py
+++ b/test/test_random_pipelines.py
@@ -1,7 +1,7 @@
 import unittest
 
 from experimenter.experiments.random import RandomArchitectureExperimenter
-from experimenter.constants import models, preprocessors
+from experimenter.constants import models, bulletproof_preprocessors
 from experimenter.pipeline_builder import EZPipeline
 from experimenter.run_pipeline import RunPipeline
 
@@ -15,7 +15,7 @@ class TestRandomPipelines(unittest.TestCase):
         self.volumes_dir = "/volumes"
         self.problem_path = "/datasets/seed_datasets_current/185_baseball"
         self.experiment = RandomArchitectureExperimenter()
-        self.preprocessors = preprocessors
+        self.preprocessors = bulletproof_preprocessors
         self.models = models
     
     def test_can_generate_pipeline(self) -> None:


### PR DESCRIPTION
Closes #51.

When reviewing this PR, I would recommend looking at the changes for each commit one at a time.

- Allows `EZPipeline` instance to track custom refs
- Adds more working pre-processors and classifiers and removes not working ones
- Fixes bugs related to changing default hyperparameters
- Changes data's flow through pipeline primitives
- Allows mapping pipeline arguments to custom data reference
- Unifies argument names and adds "subscribe to CLI args" paradigm
- Adds CLI arguments used by random experiment
- Adds random experiment