### PR TITLE
Use common random seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,10 @@ or specific db commands see `get_documents.py`.
 
 # Contributing
 
+#### Development Mode
+
 When developing, always have the `MODE` environment variable set to `development` to interact with the development mongodb instance instead of the production one. The easiest thing to do is change the value for `MODE` inside your `.env` file.
+
+#### Random Numbers
+
+For reproducibility, when using random numbers in the repo, use the `random_seed` variable importable from `experimenter.config` to seed your random number generator. If you are using the native `random` python package, you can import `random` from `experimenter.config`. It is a version of the `random` package that's already been seeded with the repo's shared seed. If you want the tests to run deterministically, supply an environment variable called `SEED` with the same value each time. The repo will then use that value as it's common random seed.

--- a/experimenter/config.py
+++ b/experimenter/config.py
@@ -1,0 +1,20 @@
+import random
+import os
+
+from d3m import index as d3m_index
+from byudml.imputer.random_sampling_imputer import RandomSamplingImputer
+
+# If SEED is provided as an environment variable, use that as
+# the random seed. Otherwise, use a random one.
+random_seed = os.getenv('SEED', random.randint(1, 1000000))
+random.seed(random_seed)
+print("Using random seed", random_seed)
+
+# TODO: Once the `fix-imputer` branch of our d3m-primitives repo
+# has been merged and the package re-released to pypi and the new
+# pypi version is on the d3m docker image, we can just import
+# d3m.index directly and not need to use this modified one.
+d3m_index.register_primitive(
+    RandomSamplingImputer.metadata.query()['python_path'],
+    RandomSamplingImputer
+)

--- a/experimenter/constants.py
+++ b/experimenter/constants.py
@@ -1,15 +1,5 @@
 from d3m.metadata.base import ArgumentType, PrimitiveFamily
-from d3m import index as d3m_index
 from byudml.imputer.random_sampling_imputer import RandomSamplingImputer
-
-# TODO: Once the `fix-imputer` branch of our d3m-primitives repo
-# has been merged and the package re-released to pypi and the new
-# pypi version is on the d3m docker image, we can just import
-# d3m.index directly and not need to use this modified one.
-d3m_index.register_primitive(
-    RandomSamplingImputer.metadata.query()['python_path'],
-    RandomSamplingImputer
-)
 
 # It is ok to use these temperamental preprocessors in production because
 # we're ok with some pipelines degenerating on some datasets.
@@ -104,11 +94,6 @@ problem_directories = [
     "training_datasets/LL0/",
     # "training_datasets/LL1/",
 ]
-
-TEST_DATASET_PATHS = {
-    '38_sick': '/datasets/seed_datasets_current/38_sick',
-    '1491_one_hundred_plant_margins': '/datasets/seed_datasets_current/1491_one_hundred_plants_margin'
-}
 
 # This is the full list of families:
 # https://metadata.datadrivendiscovery.org/schemas/v0/definitions.json#/definitions/primitive_family

--- a/experimenter/experimenter.py
+++ b/experimenter/experimenter.py
@@ -1,8 +1,7 @@
 
 import logging
 logger = logging.getLogger(__name__)
-from random import sample
-from .constants import models, d3m_index, preprocessors, problem_directories, blacklist_non_tabular_data
+from .constants import models, preprocessors, problem_directories, blacklist_non_tabular_data
 from d3m import utils as d3m_utils
 from d3m.primitive_interfaces.base import PrimitiveBase
 from d3m.metadata.pipeline import PrimitiveStep
@@ -22,7 +21,7 @@ from experimenter.experiments.random import RandomArchitectureExperimenter
 from experimenter.experiments.straight import StraightArchitectureExperimenter
 from experimenter.experiments.ensemble import EnsembleArchitectureExperimenter
 from experimenter.experiments.stacked import StackedArchitectureExperimenter
-
+from experimenter.config import d3m_index
 from experimenter import utils
 
 

--- a/experimenter/experiments/ensemble.py
+++ b/experimenter/experiments/ensemble.py
@@ -2,7 +2,6 @@ import logging
 logger = logging.getLogger(__name__)
 from typing import Dict, List
 from itertools import combinations
-from random import sample
 
 from d3m.metadata.pipeline import Pipeline, PrimitiveStep
 from d3m.primitive_interfaces.base import PrimitiveBase
@@ -10,7 +9,7 @@ from d3m.metadata.base import Context, ArgumentType
 
 from experimenter.experiments.experiment import Experiment
 from experimenter.pipeline_builder import EZPipeline, PipelineArchDesc
-from experimenter.constants import d3m_index
+from experimenter.config import d3m_index, random
 
 
 class EnsembleArchitectureExperimenter(Experiment):
@@ -211,7 +210,7 @@ class EnsembleArchitectureExperimenter(Experiment):
                     logger.info("Randomly sampling models")
                     # Generate k pipelines with randomly sampled models
                     for index in range(len(models_to_use)):
-                        algorithm = sample(models_to_use, 1)[0]
+                        algorithm = random.sample(models_to_use, 1)[0]
                         if index == k_ensembles:
                             break
                         model_list.append(algorithm)
@@ -241,7 +240,7 @@ class EnsembleArchitectureExperimenter(Experiment):
                     # randomly sample preprocessors
                     for index in range(k_ensembles):
                         # get p preprocessor for each model
-                        pre = sample(preprocessors, n_preprocessors)
+                        pre = random.sample(preprocessors, n_preprocessors)
                         for p in pre:
                             preprocessor_list.append([p])
                 logger.info(model_list)

--- a/experimenter/experiments/random.py
+++ b/experimenter/experiments/random.py
@@ -1,7 +1,6 @@
 from typing import Dict, List, Tuple, Set, Optional
 from collections import defaultdict
 from copy import copy
-import random
 import itertools
 
 from d3m.metadata.pipeline import Pipeline, PrimitiveStep
@@ -10,7 +9,8 @@ from d3m.metadata.base import Context, ArgumentType
 from experimenter.experiments.experiment import Experiment
 from experimenter.pipeline_builder import EZPipeline, PipelineArchDesc
 from experimenter.utils import multiply
-from experimenter.constants import primitives_needing_gt_one_column, d3m_index
+from experimenter.constants import primitives_needing_gt_one_column
+from experimenter.config import d3m_index, random
 
 class RandomArchitectureExperimenter(Experiment):
     """

--- a/experimenter/experiments/straight.py
+++ b/experimenter/experiments/straight.py
@@ -6,7 +6,7 @@ from d3m.metadata.base import Context, ArgumentType
 
 from experimenter.experiments.experiment import Experiment
 from experimenter.pipeline_builder import EZPipeline, PipelineArchDesc
-from experimenter.constants import d3m_index
+from experimenter.config import d3m_index
 
 
 class StraightArchitectureExperimenter(Experiment):

--- a/experimenter/pipeline_builder.py
+++ b/experimenter/pipeline_builder.py
@@ -7,8 +7,8 @@ from d3m.metadata.pipeline import PrimitiveStep, StepBase
 from d3m.metadata.base import ArgumentType
 from d3m.primitive_interfaces.base import PrimitiveBase
 
-from experimenter.constants import EXTRA_HYPEREPARAMETERS, PRIMITIVE_FAMILIES, d3m_index
-
+from experimenter.constants import EXTRA_HYPEREPARAMETERS, PRIMITIVE_FAMILIES
+from experimenter.config import d3m_index
 
 class PipelineArchDesc:
     """

--- a/experimenter/run_fit_pipeline.py
+++ b/experimenter/run_fit_pipeline.py
@@ -10,7 +10,6 @@ from d3m.metadata import (base as metadata_base, problem as base_problem, pipeli
 from d3m.metadata.pipeline_run import RuntimeEnvironment
 from d3m.container.dataset import ComputeDigest
 from d3m.runtime import fit, get_dataset, Runtime
-from experimenter.config import random_seed
 
 class RunFitPipeline:
     """
@@ -80,7 +79,7 @@ class RunFitPipeline:
         try:
             runtime, outputs, results_list = self.our_fit(
                 pipeline, problem_description, inputs,
-                context=context, random_seed=random_seed,
+                context=context,
                 volumes_dir=self.volumes_dir,
                 runtime_environment=runtime_environment,
             )
@@ -113,7 +112,7 @@ class RunFitPipeline:
         runtime = Runtime(
             pipeline, hyperparams,
             problem_description=problem_description, context=context,
-            random_seed=random_seed, volumes_dir=volumes_dir,
+            volumes_dir=volumes_dir,
             is_standard_pipeline=False, environment=runtime_environment,
         )
 

--- a/experimenter/run_fit_pipeline.py
+++ b/experimenter/run_fit_pipeline.py
@@ -10,7 +10,7 @@ from d3m.metadata import (base as metadata_base, problem as base_problem, pipeli
 from d3m.metadata.pipeline_run import RuntimeEnvironment
 from d3m.container.dataset import ComputeDigest
 from d3m.runtime import fit, get_dataset, Runtime
-
+from experimenter.config import random_seed
 
 class RunFitPipeline:
     """
@@ -46,14 +46,13 @@ class RunFitPipeline:
                          }
 
 
-    def run(self, pipeline: pipeline_module.Pipeline, random_seed: int = 0) -> list:
+    def run(self, pipeline: pipeline_module.Pipeline) -> list:
         """
         This function is what actually executes the pipeline, splits it, and returns the final predictions and scores. 
         Note that this function is EXTREMELY simimlar to that of `_evaluate` in the Runtime code. The aforementioned
         function does not allow for returning the data, so it did not fit in the workflow.
 
         :param pipeline: the pipeline object to be run OR the path to the pipeline file to be used
-        :param random_seed: the random seed that the runtime will use to evalutate the pipeline
         :returns results_list: a list containing, in order, scores from the pipeline predictions, the fit pipeline_run 
             and the produce pipeline_run.
         """
@@ -93,7 +92,7 @@ class RunFitPipeline:
 
 
     def our_fit(self, pipeline: pipeline_module.Pipeline, problem_description: typing.Dict, inputs: typing.Sequence[container.Dataset], *,
-    context: metadata_base.Context, hyperparams: typing.Sequence = None, random_seed: int = 0, volumes_dir: str = None,
+    context: metadata_base.Context, hyperparams: typing.Sequence = None, volumes_dir: str = None,
     runtime_environment: pipeline_run_module.RuntimeEnvironment = None,
     ) -> typing.Tuple[Runtime, container.DataFrame, pipeline_run_module.PipelineRun]:
         """

--- a/experimenter/run_pipeline.py
+++ b/experimenter/run_pipeline.py
@@ -10,6 +10,7 @@ from d3m.metadata.pipeline import Pipeline
 from d3m.metadata.pipeline_run import RuntimeEnvironment
 from d3m.container.dataset import ComputeDigest
 from d3m.runtime import get_metrics_from_problem_description, evaluate, get_pipeline, get_dataset
+from experimenter.config import random_seed
 
 class RunPipeline:
 
@@ -44,14 +45,13 @@ class RunPipeline:
                          }
 
     
-    def run(self, pipeline: Pipeline, random_seed: int=0) -> list:
+    def run(self, pipeline: Pipeline) -> list:
         """
         This function is what actually executes the pipeline, splits it, and returns the final predictions and scores. 
         Note that this function is EXTREMELY simimlar to that of `_evaluate` in the Runtime code. The aforementioned
         function does not allow for returning the data, so it did not fit in the workflow.
         
         :param pipeline: the pipeline object to be run OR the path to the pipeline file to be used
-        :param random_seed: the random seed that the runtime will use to evalutate the pipeline
         :returns results_list: a list containing, in order, the scores from the pipeline predictions, the fit pipeline_run 
             and the produce pipeline_run.
         """

--- a/experimenter/run_pipeline.py
+++ b/experimenter/run_pipeline.py
@@ -10,7 +10,6 @@ from d3m.metadata.pipeline import Pipeline
 from d3m.metadata.pipeline_run import RuntimeEnvironment
 from d3m.container.dataset import ComputeDigest
 from d3m.runtime import get_metrics_from_problem_description, evaluate, get_pipeline, get_dataset
-from experimenter.config import random_seed
 
 class RunPipeline:
 
@@ -119,9 +118,7 @@ class RunPipeline:
 
         all_scores, all_results = evaluate(
             pipeline, data_pipeline, scoring_pipeline, problem_description, inputs, data_params, metrics,
-            context=context, random_seed=random_seed,
-            data_random_seed=random_seed,
-            scoring_random_seed=random_seed,
+            context=context,
             volumes_dir=self.volumes_dir,
             runtime_environment=runtime_environment,
         )

--- a/test/config.py
+++ b/test/config.py
@@ -1,0 +1,15 @@
+from experimenter.config import random
+
+TEST_DATASET_PATHS = {
+    'sick': '/datasets/seed_datasets_current/38_sick',
+    # TODO: Uncomment once the one hot encoder logic is
+    # revamped, so a test can be randomly chosen each time
+    # the tests are run.
+    # 'one_hundred_plants_margin': '/datasets/seed_datasets_current/1491_one_hundred_plants_margin',
+    # 'autoMpg': '/datasets/seed_datasets_current/196_autoMpg',
+    # 'baseball': '/datasets/seed_datasets_current/185_baseball'
+}
+
+problem_name, = random.sample(TEST_DATASET_PATHS.keys(), 1)
+print(f'Using "{problem_name}" problem for tests')
+problem_path: str = TEST_DATASET_PATHS[problem_name]

--- a/test/test_ensembling_pipeline_runs.py
+++ b/test/test_ensembling_pipeline_runs.py
@@ -1,11 +1,12 @@
 import typing
 import unittest
 from experimenter.experimenter import *
-from experimenter.constants import models, preprocessors, TEST_DATASET_PATHS
+from experimenter.constants import models, preprocessors
 from d3m import runtime as runtime_module
 from d3m.metadata import pipeline as pipeline_module
 from experimenter.run_pipeline import RunPipeline
 from experimenter.experiments.ensemble import EnsembleArchitectureExperimenter
+from test.config import problem_path
 
 
 def get_pipeline(
@@ -57,7 +58,6 @@ class TestEnsemblingPipelineRuns(unittest.TestCase):
                                                                    same_preprocessor_order=False,
                                                                    problem_type="classification")
         pipeline_to_run = generated_pipelines["classification"][0]
-        problem_path = TEST_DATASET_PATHS['38_sick']
         self.run_experimenter_from_pipeline(problem_path, pipeline_to_run)
 
     def test_experimenter_run_works_and_generates_fixed(self):
@@ -70,7 +70,6 @@ class TestEnsemblingPipelineRuns(unittest.TestCase):
                                                                    problem_type="classification",
                                                                    model=model)
         pipeline_to_run = generated_pipelines["classification"][0]
-        problem_path = TEST_DATASET_PATHS['38_sick']
         self.run_experimenter_from_pipeline(problem_path, pipeline_to_run)
 
     def test_experimenter_run_works_and_generates_LARGE(self):
@@ -81,7 +80,6 @@ class TestEnsemblingPipelineRuns(unittest.TestCase):
                                                                    same_preprocessor_order=False,
                                                                    problem_type="classification")
         pipeline_to_run = generated_pipelines["classification"][0]
-        problem_path = TEST_DATASET_PATHS['38_sick']
         self.run_experimenter_from_pipeline(problem_path, pipeline_to_run)
 
     def run_experimenter_from_pipeline(self, problem_path, pipeline_to_run=None):

--- a/test/test_pipeline_generator.py
+++ b/test/test_pipeline_generator.py
@@ -2,7 +2,7 @@ import sys
 import unittest
 
 from experimenter.experimenter import Experimenter
-from experimenter.constants import TEST_DATASET_PATHS
+from test.config import TEST_DATASET_PATHS
 
 
 class PipelineGenerationTestCase(unittest.TestCase):
@@ -28,10 +28,7 @@ class PipelineGenerationTestCase(unittest.TestCase):
 
     def test_get_classification_problems(self):
         # 196_auto_mpg is regression
-        known_seed_classification_problems_test = set({
-            TEST_DATASET_PATHS['38_sick'],
-            TEST_DATASET_PATHS['1491_one_hundred_plant_margins']
-        })
+        known_seed_classification_problems_test = set(TEST_DATASET_PATHS.values())
 
         found_problems = set(self.experimenter_driver.problems['classification'])
         for known_problem in known_seed_classification_problems_test:

--- a/test/test_random_pipelines.py
+++ b/test/test_random_pipelines.py
@@ -1,9 +1,10 @@
 import unittest
 
 from experimenter.experiments.random import RandomArchitectureExperimenter
-from experimenter.constants import models, bulletproof_preprocessors, TEST_DATASET_PATHS
+from experimenter.constants import models, bulletproof_preprocessors
 from experimenter.pipeline_builder import EZPipeline
 from experimenter.run_pipeline import RunPipeline
+from test.config import problem_path
 
 
 class TestRandomPipelines(unittest.TestCase):
@@ -13,7 +14,6 @@ class TestRandomPipelines(unittest.TestCase):
     def setUp(self):
         self.datasets_dir = "/datasets"
         self.volumes_dir = "/volumes"
-        self.problem_path = TEST_DATASET_PATHS['38_sick']
         self.experiment = RandomArchitectureExperimenter()
         self.preprocessors = bulletproof_preprocessors
         self.models = models
@@ -82,7 +82,7 @@ class TestRandomPipelines(unittest.TestCase):
         run_pipeline = RunPipeline(
             datasets_dir=self.datasets_dir,
             volumes_dir=self.volumes_dir,
-            problem_path=self.problem_path
+            problem_path=problem_path
         )
         scores_test, _ = run_pipeline.run(pipeline=pipeline_to_run)
         # the value of score is in the first document in the first index


### PR DESCRIPTION
Uses a common random seed across the repo, which can be set by providing a `SEED` environment variable e.g. `SEED=200 python run_tests.py`. That allows the package and tests to be run deterministically if needed. Also adds `experimenter.config` and `test.config` modules.