### PR TITLE
Use BYU Fork of Dsbox Encoder

### DIFF
--- a/experimenter/config.py
+++ b/experimenter/config.py
@@ -4,6 +4,8 @@ import os
 from d3m import index as d3m_index
 from byudml.imputer.random_sampling_imputer import RandomSamplingImputer
 
+from experimenter.primitives.dsbox_encoder import Encoder
+
 # If SEED is provided as an environment variable, use that as
 # the random seed. Otherwise, use a random one.
 random_seed = os.getenv('SEED', random.randint(1, 1000000))
@@ -12,9 +14,15 @@ print("Using random seed", random_seed)
 
 # TODO: Once the `fix-imputer` branch of our d3m-primitives repo
 # has been merged and the package re-released to pypi and the new
-# pypi version is on the d3m docker image, we can just import
+# pypi version is on the d3m docker image, AND once this bug:
+# https://github.com/usc-isi-i2/dsbox-primitives/issues/9 is fixed,
+# in the DSBOX encoder primitive, we can just import
 # d3m.index directly and not need to use this modified one.
 d3m_index.register_primitive(
     RandomSamplingImputer.metadata.query()['python_path'],
     RandomSamplingImputer
+)
+d3m_index.register_primitive(
+    Encoder.metadata.query()['python_path'],
+    Encoder
 )

--- a/experimenter/constants.py
+++ b/experimenter/constants.py
@@ -1,5 +1,11 @@
 from d3m.metadata.base import ArgumentType, PrimitiveFamily
-from byudml.imputer.random_sampling_imputer import RandomSamplingImputer
+from d3m import utils as d3m_utils
+
+
+PACKAGE_NAME = "d3m-experimenter"
+REPOSITORY = "https://github.com/byu-dml/d3m-experimenter"
+TAG_NAME = utils.current_git_commit(os.path.dirname(__file__))
+D3M_PERFORMER_TEAM = "byu-dml"
 
 # It is ok to use these temperamental preprocessors in production because
 # we're ok with some pipelines degenerating on some datasets.

--- a/experimenter/constants.py
+++ b/experimenter/constants.py
@@ -1,10 +1,12 @@
+import os
+
 from d3m.metadata.base import ArgumentType, PrimitiveFamily
 from d3m import utils as d3m_utils
 
 
 PACKAGE_NAME = "d3m-experimenter"
 REPOSITORY = "https://github.com/byu-dml/d3m-experimenter"
-TAG_NAME = utils.current_git_commit(os.path.dirname(__file__))
+TAG_NAME = d3m_utils.current_git_commit(os.path.dirname(__file__))
 D3M_PERFORMER_TEAM = "byu-dml"
 
 # It is ok to use these temperamental preprocessors in production because

--- a/experimenter/pipeline_builder.py
+++ b/experimenter/pipeline_builder.py
@@ -205,7 +205,7 @@ class EZPipeline(Pipeline):
 
             # Next the encoder step
             self.add_primitive_step(
-                'd3m.primitives.data_transformation.one_hot_encoder.SKlearn'
+                "d3m.primitives.data_cleaning.label_encoder.DSBOX"
             )
     
     def create_primitive_step(
@@ -365,44 +365,10 @@ class EZPipeline(Pipeline):
         self.add_primitive_step(
             'd3m.primitives.data_preprocessing.random_sampling_imputer.BYU'
         )
-        self.set_step_i_of('imputed')
-
-        # extract_columns_by_semantic_types(categories) step
-        self.add_primitive_step(
-            'd3m.primitives.data_transformation.extract_columns_by_semantic_types.DataFrameCommon',
-            value_hyperparams={
-                'semantic_types': [
-                    'https://metadata.datadrivendiscovery.org/types/CategoricalData',
-                    'https://metadata.datadrivendiscovery.org/types/OrdinalData'
-                ]
-            }
-        )
-        self.set_step_i_of('categorical_attrs')
-
-        # extract_columns_by_semantic_types(non-categorical) step
-        self.add_primitive_step(
-            'd3m.primitives.data_transformation.extract_columns_by_semantic_types.DataFrameCommon',
-            self.data_ref_of('imputed'),
-            value_hyperparams={
-                'semantic_types': [
-                    'https://metadata.datadrivendiscovery.org/types/CategoricalData',
-                    'https://metadata.datadrivendiscovery.org/types/OrdinalData'
-                ],
-                'negate': True
-            }
-        )
-        self.set_step_i_of('non_categorical_attrs')
 
         # encoder step
         self.add_primitive_step(
-            'd3m.primitives.data_transformation.one_hot_encoder.SKlearn',
-            self.data_ref_of('categorical_attrs')
-        )
-        self.set_step_i_of('one_hot_categorical_attrs')
-
-        self.concatenate_inputs(
-            self.data_ref_of('one_hot_categorical_attrs'),
-            self.data_ref_of('non_categorical_attrs')
+            'd3m.primitives.data_preprocessing.dsbox_encoder.BYU'
         )
         self.set_step_i_of('attrs')
     

--- a/experimenter/primitives/dsbox_encoder.py
+++ b/experimenter/primitives/dsbox_encoder.py
@@ -1,0 +1,317 @@
+import logging
+import typing
+
+import frozendict  # type: ignore
+import numpy as np  # type: ignore
+import pandas as pd  # type: ignore
+
+from d3m import container
+from d3m.base import utils
+from d3m.metadata import hyperparams, params
+import d3m.metadata.base as mbase
+from d3m.metadata.base import DataMetadata
+from d3m.metadata.hyperparams import UniformInt
+from d3m.primitive_interfaces.base import CallResult
+from d3m.primitive_interfaces.unsupervised_learning import UnsupervisedLearnerPrimitiveBase
+
+import experimenter.constants
+
+_logger = logging.getLogger(__name__)
+
+Input = container.DataFrame
+Output = container.DataFrame
+
+
+class EncParams(params.Params):
+    mapping: typing.Dict
+    cat_columns: typing.List[str]
+    empty_columns: typing.List[int]
+
+
+class EncHyperparameter(hyperparams.Hyperparams):
+    n_limit = UniformInt(lower=0, upper=100, default=12,
+                         description='Limits the maximum number of columns generated from a single categorical column',
+                         semantic_types=['http://schema.org/Integer',
+                                         'https://metadata.datadrivendiscovery.org/types/TuningParameter'])
+    use_columns = hyperparams.Set(
+        elements=hyperparams.Hyperparameter[int](-1),
+        default=(),
+        semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter'],
+        description="A set of column indices to force primitive to operate on. If any specified column cannot be parsed, it is skipped.",
+    )
+    exclude_columns = hyperparams.Set(
+        elements=hyperparams.Hyperparameter[int](-1),
+        default=(),
+        semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter'],
+        description="A set of column indices to not operate on. Applicable only if \"use_columns\" is not provided.",
+    )
+    return_result = hyperparams.Enumeration(
+        values=['append', 'replace', 'new'],
+        default='replace',
+        semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter'],
+        description="Should parsed columns be appended, should they replace original columns, or should only parsed columns be returned? This hyperparam is ignored if use_semantic_types is set to false.",
+    )
+    use_semantic_types = hyperparams.UniformBool(
+        default=False,
+        semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter'],
+        description="Controls whether semantic_types metadata will be used for filtering columns in input dataframe. Setting this to false makes the code ignore return_result and will produce only the output dataframe"
+    )
+    add_index_columns = hyperparams.UniformBool(
+        default=True,
+        semantic_types=['https://metadata.datadrivendiscovery.org/types/ControlParameter'],
+        description="Also include primary index columns if input data has them. Applicable only if \"return_result\" is set to \"new\".",
+    )
+
+
+class Encoder(UnsupervisedLearnerPrimitiveBase[Input, Output, EncParams, EncHyperparameter]):
+    """
+    This is a BYU fork of ISI's d3m.primitives.data_preprocessing.encoder.DSBOX primitive.
+    It is the exact same as version 1.5.3 of that primitive except the logic for handling
+    NaN's has a bug that prevents it from encoding integer columns properly, (see
+    https://github.com/usc-isi-i2/dsbox-primitives/issues/9).
+
+    ISI's docstring:
+    ****************
+
+    A robust one-hot encoder. Missing values are encoded as an additional column. Use hyperparamter n_limit to limit the
+    maximum number of column generated. If n_limit>0, then only the top n_limit most frequent values are encoded into
+    columns. the rest of the values are encoded into a single column."
+    """
+    metadata = hyperparams.base.PrimitiveMetadata({
+        "id": "eeb33d14-a996-4254-adcb-188bd7bcb21b",
+        "version": "0.0.1",
+        "name": "BYU Fork of ISI DSBox Data Encoder",
+        "description": "Encode data, such as one-hot encoding for categorical data",
+        "python_path": "d3m.primitives.data_preprocessing.dsbox_encoder.BYU",
+        "primitive_family": "DATA_PREPROCESSING",
+        "algorithm_types": ["ENCODE_ONE_HOT"],
+        "source": {
+            "name": constants.D3M_PERFORMER_TEAM,
+            "contact": "mailto:evanpeterson17@gmail.com",
+            "uris": [constants.REPOSITORY]
+        },
+        "keywords": ["preprocessing", "encoding"],
+        "installation": [{
+            "type" : "PIP",
+            "package_uri": f"git+{constants.REPOSITORY}@{constants.TAG_NAME}#egg={constants.PACKAGE_NAME}",
+        }],
+    })
+
+    def __repr__(self):
+        return "%s(%r)" % ('Encoder', self.__dict__)
+
+    def __init__(self, *, hyperparams: EncHyperparameter) -> None:
+
+        super().__init__(hyperparams=hyperparams)
+        self.hyperparams = hyperparams
+        self._mapping: typing.Dict = {}
+        self._input_data: Input = None
+        self._input_data_copy: Input = None
+        self._fitted: bool = False
+        self._cat_columns: typing.List[str] = []
+        # self._col_index = None
+        self._empty_columns: typing.List[str] = []
+
+    def set_training_data(self, *, inputs: Input) -> None:
+        self._input_data = inputs
+        self._fitted = False
+
+    def _trim_features(self, feature, n_limit):
+
+        topn = feature.dropna().unique()
+        if n_limit:
+            if feature.dropna().nunique() > n_limit:
+                topn = list(feature.value_counts().head(n_limit).index)
+                topn.append('other_')
+        topn = [x for x in topn if x]
+        return feature.name, topn
+
+    def fit(self, *, timeout: float = None, iterations: int = None) -> CallResult[None]:
+
+        if self._fitted:
+            return CallResult(None)
+
+        if self._input_data is None:
+            raise ValueError('Missing training(fitting) data.')
+
+        # Look at attribute columns only
+        # print('fit in', self._input_data.columns)
+        data = self._input_data.copy()
+        all_attributes = DataMetadata.list_columns_with_semantic_types(data.metadata, semantic_types=[
+            "https://metadata.datadrivendiscovery.org/types/Attribute"])
+
+        # Remove columns with all empty values, structural type str
+        numeric = DataMetadata.list_columns_with_semantic_types(
+            data.metadata, ['http://schema.org/Integer', 'http://schema.org/Float'])
+        numeric = [x for x in numeric if x in all_attributes]
+
+        self._empty_columns = []
+        _logger.debug(f'Numeric columns: {numeric}')
+        for element in numeric:
+            if data.metadata.query((mbase.ALL_ELEMENTS, element)).get('structural_type', ()) == str:
+                if pd.isnull(pd.to_numeric(data.iloc[:, element])).sum() == data.shape[0]:
+                    _logger.debug(f'Empty numeric str column: {element}')
+                    self._empty_columns.append(element)
+
+        # Remove columns with all empty values, structural numeric
+        is_empty = pd.isnull(data).sum(axis=0) == data.shape[0]
+        for i in all_attributes:
+            if is_empty.iloc[i] and i not in self._empty_columns:
+                _logger.debug(f'Empty numeric str column: {element}')
+                self._empty_columns.append(i)
+
+        _logger.debug('Removing entirely empty columns: {}'.format(data.columns[self._empty_columns]))
+
+        data = container.DataFrame.remove_columns(data, self._empty_columns)
+
+        categorical_attributes = DataMetadata.list_columns_with_semantic_types(data.metadata,
+                                                                        semantic_types=[
+                                                                            "https://metadata.datadrivendiscovery.org/types/OrdinalData",
+                                                                            "https://metadata.datadrivendiscovery.org/types/CategoricalData"])
+        all_attributes = DataMetadata.list_columns_with_semantic_types(data.metadata, semantic_types=[
+            "https://metadata.datadrivendiscovery.org/types/Attribute"])
+
+        self._cat_col_index = list(set(all_attributes).intersection(categorical_attributes))
+        self._cat_columns = data.columns[self._cat_col_index].tolist()
+
+        _logger.debug('Encoding columns: {}'.format(self._cat_columns))
+
+        mapping = {}
+        for column_name in self._cat_columns:
+            col = data[column_name]
+            temp = self._trim_features(col, self.hyperparams['n_limit'])
+            if temp:
+                mapping[temp[0]] = temp[1]
+        self._mapping = mapping
+        self._fitted = True
+        return CallResult(None, has_finished=True)
+
+    def produce(self, *, inputs: Input, timeout: float = None, iterations: int = None) -> CallResult[Output]:
+        """
+        Convert and output the input data into encoded format,
+        using the trained (fitted) encoder.
+        Notice that [colname]_other_ and [colname]_nan columns
+        are always kept for one-hot encoded columns.
+        """
+
+        self._input_data_copy = inputs.copy()
+
+        # Remove columns with all empty values
+        _logger.debug('Removing entirely empty columns: {}'.format(self._input_data_copy.columns[self._empty_columns]))
+        self._input_data_copy = container.DataFrame.remove_columns(self._input_data_copy, self._empty_columns)
+
+        # Return if there is nothing to encode
+        if len(self._cat_columns) == 0:
+            return CallResult(self._input_data_copy, True, 1)
+
+        _logger.debug('Encoding columns: {}'.format(self._cat_columns))
+
+        data_encode = self._input_data_copy[list(self._mapping.keys())]
+
+        # Get rid of false SettingWithCopyWarning
+        data_encode.is_copy = None
+        res = []
+        for column_name in self._cat_columns:
+            feature = data_encode[column_name].copy()
+            other_ = lambda x: 'Other' if (x and x not in self._mapping[column_name]) else x
+            nan_ = lambda x: x if x else np.nan
+            feature.loc[feature.notnull()] = feature[feature.notnull()].apply(other_)
+            feature = feature.apply(nan_)
+            if 'nan' not in self._mapping[column_name]:
+                self._mapping[column_name].append('nan')
+            new_column_names = ['{}_{}'.format(column_name, i) for i in self._mapping[column_name]]
+            encoded = pd.get_dummies(feature, prefix=column_name)
+            missed = [name for name in new_column_names if name not in list(encoded.columns)]
+            for m in missed:
+                # print('missing', m)
+                encoded[m] = 0
+            encoded = encoded[new_column_names]
+            res.append(encoded)
+            # data_encode.loc[:,column_name] = feature
+
+        # Drop columns that will be encoded
+        # data_rest = self._input_data_copy.drop(self._mapping.keys(), axis=1)
+        columns_names = self._input_data_copy.columns.tolist()
+        drop_indices = [columns_names.index(col) for col in self._mapping.keys()]
+        drop_indices = sorted(drop_indices)
+
+        all_categorical = False
+        try:
+            self._input_data_copy = container.DataFrame.remove_columns(self._input_data_copy, drop_indices)
+        except ValueError:
+            _logger.warning("[warn] All the attributes are categorical!")
+            all_categorical = True
+
+        # metadata for columns that are not one hot encoded
+        # self._col_index = [self._input_data_copy.columns.get_loc(c) for c in data_rest.columns]
+        # data_rest.metadata = utils.select_columns_metadata(self._input_data_copy.metadata, self._col_index)
+
+        # encode data
+        # encoded = container.DataFrame(pd.get_dummies(data_encode, dummy_na=True, prefix=self._cat_columns, prefix_sep='_',
+        #                                        columns=self._cat_columns))
+        encoded_df = container.DataFrame(pd.concat(res, axis=1))
+
+        # update metadata for existing columns
+        for index in range(len(encoded_df.columns)):
+            old_metadata = dict(encoded_df.metadata.query((mbase.ALL_ELEMENTS, index)))
+            old_metadata["structural_type"] = int
+            old_metadata["semantic_types"] = (
+                'http://schema.org/Integer', 'https://metadata.datadrivendiscovery.org/types/Attribute')
+            encoded_df.metadata = encoded_df.metadata.update((mbase.ALL_ELEMENTS, index), old_metadata)
+        # update dimensional information
+        encoded_df.metadata = encoded_df.metadata.update((), self._input_data_copy.metadata.query(()))
+        columns_query = dict(self._input_data_copy.metadata.query((mbase.ALL_ELEMENTS,)))
+        new_dimension_data = dict(columns_query['dimension'])
+        new_dimension_data['length'] = encoded_df.shape[1]
+        columns_query['dimension'] = frozendict.FrozenOrderedDict(new_dimension_data)
+        encoded_df.metadata = encoded_df.metadata.update((mbase.ALL_ELEMENTS,), frozendict.FrozenOrderedDict(columns_query))
+        # merge/concat both the dataframes
+        if not all_categorical:
+            output = container.DataFrame.horizontal_concat(self._input_data_copy, encoded_df, use_right_metadata=True)
+        else:
+            output = encoded_df
+        return CallResult(output, True, 1)
+
+    def get_params(self) -> EncParams:
+        if not self._fitted:
+            raise ValueError("Fit not performed.")
+        return EncParams(
+            mapping=self._mapping,
+            cat_columns=self._cat_columns,
+            empty_columns=self._empty_columns)
+
+    def set_params(self, *, params: EncParams) -> None:
+        self._fitted = True
+        self._mapping = params['mapping']
+        self._cat_columns = params['cat_columns']
+        self._empty_columns = params['empty_columns']
+
+    @classmethod
+    def _get_columns_to_fit(cls, inputs: Input, hyperparams: EncHyperparameter):
+        if not hyperparams['use_semantic_types']:
+            return inputs, list(range(len(inputs.columns)))
+
+        inputs_metadata = inputs.metadata
+
+        def can_produce_column(column_index: int) -> bool:
+            return cls._can_produce_column(inputs_metadata, column_index, hyperparams)
+
+        columns_to_produce, columns_not_to_produce = utils.get_columns_to_use(
+            inputs_metadata, use_columns=hyperparams['use_columns'],
+            exclude_columns=hyperparams['exclude_columns'],
+            can_use_column=can_produce_column)
+        return inputs.iloc[:, columns_to_produce], columns_to_produce
+
+    @classmethod
+    def _can_produce_column(cls, inputs_metadata: mbase.DataMetadata, column_index: int,
+                            hyperparams: EncHyperparameter) -> bool:
+        column_metadata = inputs_metadata.query((mbase.ALL_ELEMENTS, column_index))
+
+        semantic_types = column_metadata.get('semantic_types', [])
+        if len(semantic_types) == 0:
+            cls.logger.warning("No semantic types found in column metadata")
+            return False
+        if "https://metadata.datadrivendiscovery.org/types/Attribute" in semantic_types:
+            return True
+
+        return False

--- a/experimenter/primitives/dsbox_encoder.py
+++ b/experimenter/primitives/dsbox_encoder.py
@@ -14,7 +14,7 @@ from d3m.metadata.hyperparams import UniformInt
 from d3m.primitive_interfaces.base import CallResult
 from d3m.primitive_interfaces.unsupervised_learning import UnsupervisedLearnerPrimitiveBase
 
-import experimenter.constants
+from experimenter import constants
 
 _logger = logging.getLogger(__name__)
 
@@ -68,7 +68,9 @@ class Encoder(UnsupervisedLearnerPrimitiveBase[Input, Output, EncParams, EncHype
     This is a BYU fork of ISI's d3m.primitives.data_preprocessing.encoder.DSBOX primitive.
     It is the exact same as version 1.5.3 of that primitive except the logic for handling
     NaN's has a bug that prevents it from encoding integer columns properly, (see
-    https://github.com/usc-isi-i2/dsbox-primitives/issues/9).
+    https://github.com/usc-isi-i2/dsbox-primitives/issues/9). TODO: This primitive's
+    '{col_name}_other_` column is not showing up. The 'Other' values are being populated,
+    but the column is not being created in the encoding. 
 
     ISI's docstring:
     ****************

--- a/test/config.py
+++ b/test/config.py
@@ -2,12 +2,8 @@ from experimenter.config import random
 
 TEST_DATASET_PATHS = {
     'sick': '/datasets/seed_datasets_current/38_sick',
-    # TODO: Uncomment once the one hot encoder logic is
-    # revamped, so a test can be randomly chosen each time
-    # the tests are run.
-    # 'one_hundred_plants_margin': '/datasets/seed_datasets_current/1491_one_hundred_plants_margin',
-    # 'autoMpg': '/datasets/seed_datasets_current/196_autoMpg',
-    # 'baseball': '/datasets/seed_datasets_current/185_baseball'
+    'one_hundred_plants_margin': '/datasets/seed_datasets_current/1491_one_hundred_plants_margin',
+    'baseball': '/datasets/seed_datasets_current/185_baseball'
 }
 
 problem_name, = random.sample(TEST_DATASET_PATHS.keys(), 1)

--- a/test/test_dsbox_encoder.py
+++ b/test/test_dsbox_encoder.py
@@ -1,0 +1,51 @@
+import unittest
+
+import pandas as pd
+from d3m.container.pandas import DataFrame
+from d3m import index as d3m_index
+from d3m.metadata import base as metadata_base
+
+
+class PipelineGenerationTestCase(unittest.TestCase):
+
+    OneHotter = d3m_index.get_primitive('d3m.primitives.data_preprocessing.encoder.DSBOX')
+
+    def print_metadata(df: DataFrame, name: str) -> None:
+        print(f'\n"{name}" Data Frame:')
+        print(df)
+        print('column metadata:')
+        for col_i in range(df.shape[1]):
+            print(df.metadata.query_column(col_i))
+
+    df: DataFrame = DataFrame(pd.DataFrame({
+        "A": [1, 2, 1, 1],
+        "B": [1.9, 2.5, 10, 4.3]
+    }), generate_metadata=True)
+    df.metadata = df.metadata.add_semantic_type((metadata_base.ALL_ELEMENTS, 0), "https://metadata.datadrivendiscovery.org/types/CategoricalData")
+    df.metadata = df.metadata.add_semantic_type((metadata_base.ALL_ELEMENTS, 0), "https://metadata.datadrivendiscovery.org/types/Attribute")
+    df.metadata = df.metadata.add_semantic_type((metadata_base.ALL_ELEMENTS, 1), "https://metadata.datadrivendiscovery.org/types/Attribute")
+
+    df_test: DataFrame = DataFrame(pd.DataFrame({
+        "A": [1, 2, 2, 3],
+        "B": [3.4, 5.6, 1.2, 3.7]
+    }), generate_metadata=True)
+    df_test.metadata = df_test.metadata.add_semantic_type((metadata_base.ALL_ELEMENTS, 0), "https://metadata.datadrivendiscovery.org/types/CategoricalData")
+    df_test.metadata = df_test.metadata.add_semantic_type((metadata_base.ALL_ELEMENTS, 0), "https://metadata.datadrivendiscovery.org/types/Attribute")
+    df_test.metadata = df_test.metadata.add_semantic_type((metadata_base.ALL_ELEMENTS, 1), "https://metadata.datadrivendiscovery.org/types/Attribute")
+
+    print_metadata(df, 'df')
+    print_metadata(df_test, 'test df')
+
+    hyperparams_class = OneHotter.metadata.query()['primitive_code']['class_type_arguments']['Hyperparams']
+    one_hotter = OneHotter(hyperparams=hyperparams_class.defaults())
+
+    one_hotter.set_training_data(inputs=df)
+    one_hotter.fit()
+    print('one hotter mapping:')
+    print(f'mapping={one_hotter._mapping}, cat columns={one_hotter._cat_columns}')
+    after_onehot = one_hotter.produce(inputs=df).value
+    print_metadata(after_onehot, 'after_onehot')
+
+    test_after_onehot = one_hotter.produce(inputs=df_test).value
+    print_metadata(test_after_onehot, 'test_after_onehot')
+

--- a/test/test_dsbox_encoder.py
+++ b/test/test_dsbox_encoder.py
@@ -1,51 +1,162 @@
 import unittest
+from typing import Dict, List
 
 import pandas as pd
 from d3m.container.pandas import DataFrame
-from d3m import index as d3m_index
 from d3m.metadata import base as metadata_base
 
+from experimenter.config import d3m_index
 
-class PipelineGenerationTestCase(unittest.TestCase):
 
-    OneHotter = d3m_index.get_primitive('d3m.primitives.data_preprocessing.encoder.DSBOX')
+class DSBOXEncoderTestCase(unittest.TestCase):
 
-    def print_metadata(df: DataFrame, name: str) -> None:
+    def setUp(self):
+        self.Encoder = d3m_index.get_primitive('d3m.primitives.data_preprocessing.dsbox_encoder.BYU')
+        self.hyperparams_class = self.Encoder.metadata.query()['primitive_code']['class_type_arguments']['Hyperparams']
+        self.semantics = {
+            "categorical": "https://metadata.datadrivendiscovery.org/types/CategoricalData",
+            "ordinal": "https://metadata.datadrivendiscovery.org/types/OrdinalData",
+            "attribute": "https://metadata.datadrivendiscovery.org/types/Attribute"
+        }
+
+        self.categorical_data = self._make_df(
+            ["cat", "num"],
+            [
+                [1, 3.4],
+                [1, 4.5],
+                [2, 1.1],
+                [1, 8.2]
+            ],
+            [
+                [self.semantics['attribute'], self.semantics['categorical']],
+                [self.semantics['attribute']]
+            ]
+        )
+        self.categorical_data2 = self._make_df(
+            ["cat", "num"],
+            [
+                [1, 7.4],
+                [3, 1.5],
+                [2, 3.1],
+                [1, 5.2]
+            ],
+            [
+                [self.semantics['attribute'], self.semantics['categorical']],
+                [self.semantics['attribute']]
+            ]
+        )
+        self.ordinal_data = self._make_df(
+            ["ord", "num"],
+            [
+                [1, 3.4],
+                [1, 4.5],
+                [2, 1.1],
+                [1, 8.2]
+            ],
+            [
+                [self.semantics['attribute'], self.semantics['ordinal']],
+                [self.semantics['attribute']]
+            ]
+        )
+        self.numeric_data = self._make_df(
+            ["intcol", "floatcol"],
+            [
+                [1, 3.4],
+                [1, 4.5],
+                [2, 1.1],
+                [1, 8.2]
+            ],
+            [
+                [self.semantics['attribute']],
+                [self.semantics['attribute']]
+            ]
+        )
+    
+    def test_can_encode_categorical(self):
+        """
+        Ensures categorical attributes are encoded.
+        """
+        after_onehot = self._fit_produce(self.categorical_data)
+
+        self.assertEqual(after_onehot.shape, (4, 4))
+        self.assertEqual(after_onehot['cat_1'].sum(), 3)
+        self.assertEqual(after_onehot['cat_2'].sum(), 1)
+    
+    def test_can_encode_ordinal(self):
+        """
+        Ensures ordinal attributes are encoded.
+        """
+        after_onehot = self._fit_produce(self.ordinal_data)
+
+        self.assertEqual(after_onehot.shape, (4, 4))
+        self.assertEqual(after_onehot['ord_1'].sum(), 3)
+        self.assertEqual(after_onehot['ord_2'].sum(), 1)
+    
+    def test_wont_encode_non_categorical(self):
+        """
+        Ensures only attributes that are ordinal or categorical
+        are encoded.
+        """
+        after_onehot = self._fit_produce(self.numeric_data)
+        self.assertEqual(after_onehot.shape, (4,2))
+        self.assertTrue(
+            self._are_lists_equal(after_onehot.columns, ['intcol', 'floatcol'])
+        )
+    
+    def test_can_handle_unseen_values(self):
+        """
+        Ensures the primitive does not break when produced on data
+        that has values the primitive did not see while it was
+        fitting.
+        """
+        one_hotter = self._fit(self.categorical_data)
+        after_onehot = one_hotter.produce(inputs=self.categorical_data2).value
+
+        self.assertEqual(after_onehot.shape, (4, 4))
+        self.assertEqual(after_onehot['cat_1'].sum(), 2)
+        self.assertEqual(after_onehot['cat_2'].sum(), 1)
+    
+    def _are_lists_equal(self, l1, l2) -> bool:
+        if len(l1) != len(l2):
+            return False
+        return all(a == b for a, b in zip(l1, l2))
+    
+    def _fit(self, df: DataFrame):
+        one_hotter = self.Encoder(hyperparams=self.hyperparams_class.defaults())
+        one_hotter.set_training_data(inputs=df)
+        one_hotter.fit()
+        return one_hotter
+    
+    def _fit_produce(self, df: DataFrame) -> DataFrame:
+        one_hotter = self.Encoder(hyperparams=self.hyperparams_class.defaults())
+        one_hotter.set_training_data(inputs=df)
+        one_hotter.fit()
+        return one_hotter.produce(inputs=df).value
+    
+    def _make_df(
+        self,
+        col_names: List[str],
+        data: list,
+        semantic_types: List[List[str]]
+    ) -> DataFrame:
+        # Make the data
+        df: DataFrame = DataFrame(
+            pd.DataFrame(data, columns=col_names),
+            generate_metadata=True
+        )
+        # Add each column's semantic types
+        for col_i in range(df.shape[1]):
+            col_semantic_types = semantic_types[col_i]
+            for semantic_type in col_semantic_types:
+                df.metadata = df.metadata.add_semantic_type(
+                    (metadata_base.ALL_ELEMENTS, col_i),
+                    semantic_type
+                )
+        return df
+
+    def _print_metadata(self, df: DataFrame, name: str) -> None:
         print(f'\n"{name}" Data Frame:')
         print(df)
         print('column metadata:')
         for col_i in range(df.shape[1]):
             print(df.metadata.query_column(col_i))
-
-    df: DataFrame = DataFrame(pd.DataFrame({
-        "A": [1, 2, 1, 1],
-        "B": [1.9, 2.5, 10, 4.3]
-    }), generate_metadata=True)
-    df.metadata = df.metadata.add_semantic_type((metadata_base.ALL_ELEMENTS, 0), "https://metadata.datadrivendiscovery.org/types/CategoricalData")
-    df.metadata = df.metadata.add_semantic_type((metadata_base.ALL_ELEMENTS, 0), "https://metadata.datadrivendiscovery.org/types/Attribute")
-    df.metadata = df.metadata.add_semantic_type((metadata_base.ALL_ELEMENTS, 1), "https://metadata.datadrivendiscovery.org/types/Attribute")
-
-    df_test: DataFrame = DataFrame(pd.DataFrame({
-        "A": [1, 2, 2, 3],
-        "B": [3.4, 5.6, 1.2, 3.7]
-    }), generate_metadata=True)
-    df_test.metadata = df_test.metadata.add_semantic_type((metadata_base.ALL_ELEMENTS, 0), "https://metadata.datadrivendiscovery.org/types/CategoricalData")
-    df_test.metadata = df_test.metadata.add_semantic_type((metadata_base.ALL_ELEMENTS, 0), "https://metadata.datadrivendiscovery.org/types/Attribute")
-    df_test.metadata = df_test.metadata.add_semantic_type((metadata_base.ALL_ELEMENTS, 1), "https://metadata.datadrivendiscovery.org/types/Attribute")
-
-    print_metadata(df, 'df')
-    print_metadata(df_test, 'test df')
-
-    hyperparams_class = OneHotter.metadata.query()['primitive_code']['class_type_arguments']['Hyperparams']
-    one_hotter = OneHotter(hyperparams=hyperparams_class.defaults())
-
-    one_hotter.set_training_data(inputs=df)
-    one_hotter.fit()
-    print('one hotter mapping:')
-    print(f'mapping={one_hotter._mapping}, cat columns={one_hotter._cat_columns}')
-    after_onehot = one_hotter.produce(inputs=df).value
-    print_metadata(after_onehot, 'after_onehot')
-
-    test_after_onehot = one_hotter.produce(inputs=df_test).value
-    print_metadata(test_after_onehot, 'test_after_onehot')
-

--- a/test/test_pipeline_builder.py
+++ b/test/test_pipeline_builder.py
@@ -166,7 +166,7 @@ class PipelineGenerationTestCase(unittest.TestCase):
             step_paths
         )
         self.assertIn(
-            'd3m.primitives.data_transformation.one_hot_encoder.SKlearn',
+            "d3m.primitives.data_cleaning.label_encoder.DSBOX",
             step_paths
         )
         

--- a/test/test_pipeline_generator.py
+++ b/test/test_pipeline_generator.py
@@ -43,13 +43,10 @@ class PipelineGenerationTestCase(unittest.TestCase):
         # ColumnParser ->
         # ExtractSemanticTypes(attributes) ->
         # BYUImputer ->
-        # ExtractSemanticTypes(categories) ->
-        # ExtractSemanticTypes(non-categorical) ->
         # OneHotEncoder ->
-        # HorizontalConcat(one-hot-encoded, non-categorical) ->
         # SKGaussianNB ->
         # ConstructPredictions
-        num_pipeline_steps = 11
+        num_pipeline_steps = 8
         dataset_to_dataframe = 'd3m.primitives.data_transformation.dataset_to_dataframe.Common'
         construct_predictions = 'd3m.primitives.data_transformation.construct_predictions.DataFrameCommon'
 


### PR DESCRIPTION
Using a fork of `d3m.primitives.data_preprocessing.encoder.DSBOX` (unit tests included in this PR) to give us these benefits:
- One hot encoding categorical and ordinal columns of all structural types
- When encoding, if a column has more than 12 categories, we only create one hot columns for the 12 most common categories, and have a 13th column for all the less common ones (to prevent feature explosion)
- Unseen categories present in the test set will not cause the pipeline to fail
- Datasets with no categorical or ordinal columns will not cause the one hot encoding process to fail