### PR TITLE
Remove workaround that was blocked by D3M docker image update

### DIFF
--- a/experimenter/config.py
+++ b/experimenter/config.py
@@ -4,8 +4,6 @@ import logging
 
 from d3m import index as d3m_index  # noqa: F401
 
-from byudml.imputer.random_sampling_imputer import RandomSamplingImputer
-
 logger = logging.getLogger(__name__)
 
 
@@ -26,9 +24,3 @@ try:
     REDIS_PORT = int(os.environ["REDIS_PORT"])
 except Exception:
     logger.exception("environment variables not set")
-
-# TODO: remove this once the D3M docker image updates
-# with the fixes in the 0.6.8 byudml release.
-d3m_index.register_primitive(
-    RandomSamplingImputer.metadata.query()["python_path"], RandomSamplingImputer
-)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,3 @@ requests
 elasticsearch-dsl
 elasticsearch
 tqdm
-# TODO: remove this once the D3M docker image updates
-# with the fixes in this release.
-byudml==0.6.8


### PR DESCRIPTION
The new D3M docker image has been released, so removing the workaround for the imputer primitive.